### PR TITLE
Introduce Compose-based player module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,11 @@ android {
     buildFeatures {
         viewBinding = true
         buildConfig = true
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String
     }
 
     packaging {
@@ -68,6 +73,12 @@ dependencies {
 
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
+
+    implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
 
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,10 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".NewPlayerActivity"
+            android:exported="false" />
+
         <receiver
             android:name="androidx.media.session.MediaButtonReceiver"
             android:exported="true">

--- a/app/src/main/java/org/schabi/newpipe/NewPlayerActivity.kt
+++ b/app/src/main/java/org/schabi/newpipe/NewPlayerActivity.kt
@@ -1,0 +1,21 @@
+package org.schabi.newpipe
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import dagger.hilt.android.AndroidEntryPoint
+import org.schabi.newpipe.core.ui.theme.NewPipeTheme
+import org.schabi.newpipe.feature.player.NewPlayer
+
+@AndroidEntryPoint
+class NewPlayerActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val url = intent.getStringExtra("url") ?: ""
+        setContent {
+            NewPipeTheme {
+                NewPlayer().PlayerScreen(url)
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,4 +23,6 @@ allprojects {
     }
     extra["kotlin_version"] = "2.1.21"
     extra["hilt_version"] = "2.51"
+    extra["compose_compiler_version"] = "1.5.10"
+    extra["compose_bom_version"] = "2025.06.01"
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -19,8 +19,16 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    buildFeatures { compose = true }
+    composeOptions {
+        kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String
+    }
 }
 
 dependencies {
-    implementation("androidx.compose.material3:material3:1.2.1")
+    implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
 }

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/theme/NewPipeTheme.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/theme/NewPipeTheme.kt
@@ -1,0 +1,23 @@
+package org.schabi.newpipe.core.ui.theme
+
+import android.os.Build
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun NewPipeTheme(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val colorScheme = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (MaterialTheme.colorScheme.isLight) {
+            dynamicLightColorScheme(context)
+        } else {
+            dynamicDarkColorScheme(context)
+        }
+    } else {
+        MaterialTheme.colorScheme
+    }
+    MaterialTheme(colorScheme = colorScheme, content = content)
+}

--- a/feature/player/build.gradle.kts
+++ b/feature/player/build.gradle.kts
@@ -7,12 +7,24 @@ android {
     compileSdk = 36
     namespace = "org.schabi.newpipe.feature.player"
     defaultConfig { minSdk = 21 }
-    compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
     kotlinOptions { jvmTarget = "17" }
+    buildFeatures { compose = true }
+    composeOptions {
+        kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String
+    }
 }
 
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
+    implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("androidx.media3:media3-exoplayer:1.3.1")
 }

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/NewPlayer.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/NewPlayer.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.feature.player
+
+import androidx.compose.runtime.Composable
+
+class NewPlayer : PlayerContract {
+    @Composable
+    override fun PlayerScreen(url: String) {
+        DefaultPlayerScreen(url)
+    }
+}

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerContract.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerContract.kt
@@ -1,0 +1,8 @@
+package org.schabi.newpipe.feature.player
+
+import androidx.compose.runtime.Composable
+
+interface PlayerContract {
+    @Composable
+    fun PlayerScreen(url: String)
+}

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
@@ -1,0 +1,32 @@
+package org.schabi.newpipe.feature.player
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import androidx.compose.ui.viewinterop.AndroidView
+
+@Composable
+fun DefaultPlayerScreen(url: String, viewModel: PlayerViewModel = hiltViewModel()) {
+    LaunchedEffect(url) {
+        viewModel.prepare(url)
+        viewModel.play()
+    }
+    val player = viewModel.getPlayer()
+    DisposableEffect(Unit) {
+        onDispose {
+            player?.release()
+        }
+    }
+    AndroidView(modifier = Modifier.fillMaxSize(), factory = { context ->
+        PlayerView(context).apply {
+            this.player = player
+        }
+    })
+}

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
@@ -1,0 +1,41 @@
+package org.schabi.newpipe.feature.player
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PlayerViewModel @Inject constructor(
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    private var player: ExoPlayer? = null
+
+    fun prepare(url: String) {
+        if (player == null) {
+            player = ExoPlayer.Builder(context).build()
+        }
+        player?.setMediaItem(MediaItem.fromUri(url))
+        player?.prepare()
+    }
+
+    fun play() {
+        player?.play()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        viewModelScope.launch {
+            player?.release()
+            player = null
+        }
+    }
+
+    fun getPlayer(): ExoPlayer? = player
+}


### PR DESCRIPTION
## Summary
- configure Compose compiler and BOM versions in root gradle file
- enable Compose in `core:ui` and add basic `NewPipeTheme`
- set up `feature:player` with Compose and Media3
- add Compose dependencies and new `NewPlayerActivity`
- register the activity in `AndroidManifest`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684211bbcf888322a687ce36ab902d69