### PR TITLE
Add core data/domain modules and integrate DI

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -17,4 +17,8 @@ dependencies {
     implementation("androidx.room:room-runtime:2.7.1")
     kapt("androidx.room:room-compiler:2.7.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.1")
+    implementation("com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.6")
+    implementation("androidx.datastore:datastore-preferences:1.1.0")
+    implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
+    kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DataModule.kt
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.core.data.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.schabi.newpipe.core.data.repository.HistoryRepository
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.data.repository.StreamRepository
+import org.schabi.newpipe.core.data.repository.impl.DefaultHistoryRepository
+import org.schabi.newpipe.core.data.repository.impl.DefaultPlaylistRepository
+import org.schabi.newpipe.core.data.repository.impl.DefaultStreamRepository
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataModule {
+    @Binds
+    abstract fun bindStreamRepository(impl: DefaultStreamRepository): StreamRepository
+
+    @Binds
+    abstract fun bindPlaylistRepository(impl: DefaultPlaylistRepository): PlaylistRepository
+
+    @Binds
+    abstract fun bindHistoryRepository(impl: DefaultHistoryRepository): HistoryRepository
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/preferences/PreferenceDataStore.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/preferences/PreferenceDataStore.kt
@@ -1,0 +1,22 @@
+package org.schabi.newpipe.core.data.preferences
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class PreferenceDataStore(private val context: Context) {
+    private val Context.dataStore by preferencesDataStore(name = "settings")
+
+    private val watchHistoryKey = booleanPreferencesKey("enable_watch_history")
+
+    val isWatchHistoryEnabled: Flow<Boolean> =
+        context.dataStore.data.map { it[watchHistoryKey] ?: false }
+
+    suspend fun setWatchHistoryEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[watchHistoryKey] = enabled }
+    }
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/HistoryRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/HistoryRepository.kt
@@ -1,0 +1,8 @@
+package org.schabi.newpipe.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface HistoryRepository {
+    val isWatchHistoryEnabled: Flow<Boolean>
+    suspend fun setWatchHistoryEnabled(enabled: Boolean)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/PlaylistRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/PlaylistRepository.kt
@@ -1,0 +1,7 @@
+package org.schabi.newpipe.core.data.repository
+
+import org.schabi.newpipe.core.model.Playlist
+
+interface PlaylistRepository {
+    suspend fun getPlaylist(url: String): Playlist
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/StreamRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/StreamRepository.kt
@@ -1,0 +1,7 @@
+package org.schabi.newpipe.core.data.repository
+
+import org.schabi.newpipe.core.model.Stream
+
+interface StreamRepository {
+    suspend fun getStream(url: String): Stream
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultHistoryRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultHistoryRepository.kt
@@ -1,0 +1,14 @@
+package org.schabi.newpipe.core.data.repository.impl
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.schabi.newpipe.core.data.preferences.PreferenceDataStore
+import org.schabi.newpipe.core.data.repository.HistoryRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class DefaultHistoryRepository @Inject constructor(@ApplicationContext context: Context) : HistoryRepository {
+    private val prefs = PreferenceDataStore(context)
+    override val isWatchHistoryEnabled: Flow<Boolean> = prefs.isWatchHistoryEnabled
+    override suspend fun setWatchHistoryEnabled(enabled: Boolean) = prefs.setWatchHistoryEnabled(enabled)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultPlaylistRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultPlaylistRepository.kt
@@ -1,0 +1,18 @@
+package org.schabi.newpipe.core.data.repository.impl
+
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.model.Playlist
+import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.playlist.PlaylistInfo
+
+class DefaultPlaylistRepository : PlaylistRepository {
+    override suspend fun getPlaylist(url: String): Playlist {
+        val service = NewPipe.getServiceByUrl(url)
+        val info = PlaylistInfo.getInfo(service, url)
+        return Playlist(
+            url = info.url,
+            name = info.name,
+            thumbnailUrl = info.avatarUrl
+        )
+    }
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultStreamRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultStreamRepository.kt
@@ -1,0 +1,20 @@
+package org.schabi.newpipe.core.data.repository.impl
+
+import org.schabi.newpipe.core.data.repository.StreamRepository
+import org.schabi.newpipe.core.model.Stream
+import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.stream.StreamInfo
+
+class DefaultStreamRepository : StreamRepository {
+    override suspend fun getStream(url: String): Stream {
+        val service = NewPipe.getServiceByUrl(url)
+        val info = StreamInfo.getInfo(service, url)
+        return Stream(
+            url = info.url,
+            title = info.name,
+            thumbnailUrl = info.thumbnailUrl,
+            duration = info.duration,
+            uploader = info.uploaderName
+        )
+    }
+}

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     kotlin("android")
+    kotlin("kapt")
 }
 
 android {
@@ -15,4 +16,6 @@ dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:data"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.1")
+    implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
+    kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
@@ -1,0 +1,16 @@
+package org.schabi.newpipe.core.domain.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.schabi.newpipe.core.data.repository.StreamRepository
+import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DomainModule {
+    @Provides
+    fun provideGetStreamDetailsUseCase(repository: StreamRepository): GetStreamDetailsUseCase =
+        GetStreamDetailsUseCase(repository)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetStreamDetailsUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetStreamDetailsUseCase.kt
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.schabi.newpipe.core.data.repository.StreamRepository
+import org.schabi.newpipe.core.model.Stream
+import javax.inject.Inject
+
+class GetStreamDetailsUseCase @Inject constructor(
+    private val repository: StreamRepository
+) {
+    suspend operator fun invoke(url: String): Flow<Result<Stream>> = flow {
+        emit(runCatching { repository.getStream(url) })
+    }
+}

--- a/core/model/src/main/java/org/schabi/newpipe/core/model/Channel.kt
+++ b/core/model/src/main/java/org/schabi/newpipe/core/model/Channel.kt
@@ -1,0 +1,7 @@
+package org.schabi.newpipe.core.model
+
+data class Channel(
+    val url: String,
+    val name: String,
+    val avatarUrl: String?
+)

--- a/core/model/src/main/java/org/schabi/newpipe/core/model/Playlist.kt
+++ b/core/model/src/main/java/org/schabi/newpipe/core/model/Playlist.kt
@@ -1,0 +1,7 @@
+package org.schabi.newpipe.core.model
+
+data class Playlist(
+    val url: String,
+    val name: String,
+    val thumbnailUrl: String?
+)

--- a/core/model/src/main/java/org/schabi/newpipe/core/model/Stream.kt
+++ b/core/model/src/main/java/org/schabi/newpipe/core/model/Stream.kt
@@ -1,0 +1,9 @@
+package org.schabi.newpipe.core.model
+
+data class Stream(
+    val url: String,
+    val title: String,
+    val thumbnailUrl: String?,
+    val duration: Long,
+    val uploader: String?
+)

--- a/feature/player/build.gradle.kts
+++ b/feature/player/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     kotlin("android")
+    kotlin("kapt")
 }
 
 android {
@@ -27,4 +28,6 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("androidx.media3:media3-exoplayer:1.3.1")
+    implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
+    kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
 }

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
@@ -21,7 +21,7 @@ fun DefaultPlayerScreen(url: String, viewModel: PlayerViewModel = hiltViewModel(
     val player = viewModel.getPlayer()
     DisposableEffect(Unit) {
         onDispose {
-            player?.release()
+            player.release()
         }
     }
     AndroidView(modifier = Modifier.fillMaxSize(), factory = { context ->

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
@@ -1,41 +1,39 @@
 package org.schabi.newpipe.feature.player
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
 
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
-    @ApplicationContext private val context: Context
+    private val player: ExoPlayer,
+    private val getStreamDetails: GetStreamDetailsUseCase
 ) : ViewModel() {
 
-    private var player: ExoPlayer? = null
-
     fun prepare(url: String) {
-        if (player == null) {
-            player = ExoPlayer.Builder(context).build()
+        viewModelScope.launch {
+            val result = getStreamDetails(url).first()
+            result.onSuccess {
+                player.setMediaItem(MediaItem.fromUri(it.url))
+                player.prepare()
+            }
         }
-        player?.setMediaItem(MediaItem.fromUri(url))
-        player?.prepare()
     }
 
     fun play() {
-        player?.play()
+        player.play()
     }
 
     override fun onCleared() {
         super.onCleared()
-        viewModelScope.launch {
-            player?.release()
-            player = null
-        }
+        player.release()
     }
 
-    fun getPlayer(): ExoPlayer? = player
+    fun getPlayer(): ExoPlayer = player
 }

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/di/PlayerModule.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/di/PlayerModule.kt
@@ -1,0 +1,17 @@
+package org.schabi.newpipe.feature.player.di
+
+import android.content.Context
+import androidx.media3.exoplayer.ExoPlayer
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PlayerModule {
+    @Provides
+    fun provideExoPlayer(@ApplicationContext context: Context): ExoPlayer =
+        ExoPlayer.Builder(context).build()
+}


### PR DESCRIPTION
## Summary
- create basic models module for Stream, Playlist and Channel
- add repository interfaces and implementations in `core:data`
- provide DI bindings with Hilt
- add `GetStreamDetailsUseCase` in domain module
- use the new use case and injected ExoPlayer in `PlayerViewModel`
- provide ExoPlayer via `PlayerModule`
- update build scripts for new dependencies

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684218bbf7dc8322b07efada1c4074fa