### PR TITLE
Add watch history feature with database

### DIFF
--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -1,0 +1,9 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [HistoryEntryEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun historyDao(): HistoryDao
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/HistoryDao.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/HistoryDao.kt
@@ -1,0 +1,19 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface HistoryDao {
+    @Query("SELECT * FROM history ORDER BY accessDate DESC")
+    fun getHistory(): Flow<List<HistoryEntryEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entry: HistoryEntryEntity)
+
+    @Query("DELETE FROM history")
+    suspend fun clearHistory()
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/HistoryEntryEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/HistoryEntryEntity.kt
@@ -1,0 +1,13 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "history")
+data class HistoryEntryEntity(
+    @PrimaryKey val streamUrl: String,
+    val title: String,
+    val uploader: String,
+    val thumbnailUrl: String?,
+    val accessDate: Long
+)

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
@@ -1,0 +1,24 @@
+package org.schabi.newpipe.core.data.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import org.schabi.newpipe.core.data.db.AppDatabase
+import org.schabi.newpipe.core.data.db.HistoryDao
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+        Room.databaseBuilder(context, AppDatabase::class.java, "newpipe.db").build()
+
+    @Provides
+    fun provideHistoryDao(db: AppDatabase): HistoryDao = db.historyDao()
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/HistoryRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/HistoryRepository.kt
@@ -1,8 +1,11 @@
 package org.schabi.newpipe.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.model.Stream
 
 interface HistoryRepository {
     val isWatchHistoryEnabled: Flow<Boolean>
+    fun getWatchHistory(): Flow<List<Stream>>
+    suspend fun addStreamToHistory(stream: Stream)
     suspend fun setWatchHistoryEnabled(enabled: Boolean)
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultHistoryRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultHistoryRepository.kt
@@ -2,13 +2,47 @@ package org.schabi.newpipe.core.data.repository.impl
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.schabi.newpipe.core.data.db.HistoryDao
+import org.schabi.newpipe.core.data.db.HistoryEntryEntity
 import org.schabi.newpipe.core.data.preferences.PreferenceDataStore
 import org.schabi.newpipe.core.data.repository.HistoryRepository
-import kotlinx.coroutines.flow.Flow
-import javax.inject.Inject
+import org.schabi.newpipe.core.model.Stream
 
-class DefaultHistoryRepository @Inject constructor(@ApplicationContext context: Context) : HistoryRepository {
+class DefaultHistoryRepository @Inject constructor(
+    @ApplicationContext context: Context,
+    private val historyDao: HistoryDao
+) : HistoryRepository {
     private val prefs = PreferenceDataStore(context)
     override val isWatchHistoryEnabled: Flow<Boolean> = prefs.isWatchHistoryEnabled
-    override suspend fun setWatchHistoryEnabled(enabled: Boolean) = prefs.setWatchHistoryEnabled(enabled)
+
+    override fun getWatchHistory(): Flow<List<Stream>> =
+        historyDao.getHistory().map { list ->
+            list.map { entity ->
+                Stream(
+                    url = entity.streamUrl,
+                    title = entity.title,
+                    thumbnailUrl = entity.thumbnailUrl,
+                    duration = 0L,
+                    uploader = entity.uploader
+                )
+            }
+        }
+
+    override suspend fun addStreamToHistory(stream: Stream) {
+        historyDao.insert(
+            HistoryEntryEntity(
+                streamUrl = stream.url,
+                title = stream.title,
+                uploader = stream.uploader ?: "",
+                thumbnailUrl = stream.thumbnailUrl,
+                accessDate = System.currentTimeMillis()
+            )
+        )
+    }
+
+    override suspend fun setWatchHistoryEnabled(enabled: Boolean) =
+        prefs.setWatchHistoryEnabled(enabled)
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
@@ -5,8 +5,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.schabi.newpipe.core.data.repository.StreamRepository
+import org.schabi.newpipe.core.data.repository.HistoryRepository
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetTrendingStreamsUseCase
+import org.schabi.newpipe.core.domain.usecase.GetWatchHistoryUseCase
+import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -18,4 +21,12 @@ object DomainModule {
     @Provides
     fun provideGetTrendingStreamsUseCase(repository: StreamRepository): GetTrendingStreamsUseCase =
         GetTrendingStreamsUseCase(repository)
+
+    @Provides
+    fun provideGetWatchHistoryUseCase(repository: HistoryRepository): GetWatchHistoryUseCase =
+        GetWatchHistoryUseCase(repository)
+
+    @Provides
+    fun provideAddStreamToHistoryUseCase(repository: HistoryRepository): AddStreamToHistoryUseCase =
+        AddStreamToHistoryUseCase(repository)
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/AddStreamToHistoryUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/AddStreamToHistoryUseCase.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import org.schabi.newpipe.core.data.repository.HistoryRepository
+import org.schabi.newpipe.core.model.Stream
+import javax.inject.Inject
+
+class AddStreamToHistoryUseCase @Inject constructor(
+    private val repository: HistoryRepository
+) {
+    suspend operator fun invoke(stream: Stream) = repository.addStreamToHistory(stream)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetWatchHistoryUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetWatchHistoryUseCase.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.data.repository.HistoryRepository
+import org.schabi.newpipe.core.model.Stream
+import javax.inject.Inject
+
+class GetWatchHistoryUseCase @Inject constructor(
+    private val repository: HistoryRepository
+) {
+    operator fun invoke(): Flow<List<Stream>> = repository.getWatchHistory()
+}

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/StreamItem.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/StreamItem.kt
@@ -1,0 +1,21 @@
+package org.schabi.newpipe.core.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.schabi.newpipe.core.model.Stream
+
+@Composable
+fun StreamItem(stream: Stream, onClick: (Stream) -> Unit) {
+    Text(
+        text = stream.title,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .clickable { onClick(stream) }
+    )
+}

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainNavigationBar.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainNavigationBar.kt
@@ -1,0 +1,21 @@
+package org.schabi.newpipe.core.ui.components
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun MainNavigationBar(selected: MainTab, onTabSelected: (MainTab) -> Unit) {
+    NavigationBar {
+        MainTab.values().forEach { tab ->
+            NavigationBarItem(
+                selected = selected == tab,
+                onClick = { onTabSelected(tab) },
+                icon = { Icon(tab.icon, contentDescription = tab.label) },
+                label = { Text(tab.label) }
+            )
+        }
+    }
+}

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class MainTab(val route: String, val label: String, val icon: ImageVector) {
+    Trends("main", "Trends", Icons.Filled.Home),
+    History("history", "History", Icons.Filled.History)
+}

--- a/feature/history/build.gradle.kts
+++ b/feature/history/build.gradle.kts
@@ -6,28 +6,21 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.main"
+    namespace = "org.schabi.newpipe.feature.history"
     defaultConfig { minSdk = 21 }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+    compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }
     kotlinOptions { jvmTarget = "17" }
     buildFeatures { compose = true }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String
-    }
+    composeOptions { kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String }
 }
 
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
-    implementation(project(":feature:history"))
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")

--- a/feature/history/src/main/java/org/schabi/newpipe/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/org/schabi/newpipe/feature/history/HistoryScreen.kt
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.feature.main
+package org.schabi.newpipe.feature.history
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -17,23 +17,19 @@ import org.schabi.newpipe.core.ui.components.MainNavigationBar
 import org.schabi.newpipe.core.ui.components.MainTab
 
 @Composable
-fun MainScreen(
+fun HistoryScreen(
     onStreamSelected: (Stream) -> Unit,
     selectedTab: MainTab,
     onTabSelected: (MainTab) -> Unit,
-    viewModel: MainViewModel = hiltViewModel()
+    viewModel: HistoryViewModel = hiltViewModel()
 ) {
-    val state = viewModel.uiState.collectAsState().value
+    val history = viewModel.history.collectAsState().value
     Scaffold(
-        topBar = { TopAppBar(title = { Text(text = "NewPipe") }) },
+        topBar = { TopAppBar(title = { Text("History") }) },
         bottomBar = { MainNavigationBar(selectedTab, onTabSelected) }
     ) { padding ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
-            items(state.trendingStreams) { stream ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            items(history) { stream ->
                 StreamItem(stream, onStreamSelected)
             }
         }

--- a/feature/history/src/main/java/org/schabi/newpipe/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/java/org/schabi/newpipe/feature/history/HistoryViewModel.kt
@@ -1,0 +1,20 @@
+package org.schabi.newpipe.feature.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import org.schabi.newpipe.core.domain.usecase.GetWatchHistoryUseCase
+import org.schabi.newpipe.core.model.Stream
+
+@HiltViewModel
+class HistoryViewModel @Inject constructor(
+    getWatchHistoryUseCase: GetWatchHistoryUseCase
+) : ViewModel() {
+    val history: StateFlow<List<Stream>> =
+        getWatchHistoryUseCase()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+}

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
@@ -11,14 +11,25 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.navigation.NavType
 import org.schabi.newpipe.NewPlayerActivity
+import org.schabi.newpipe.feature.history.HistoryScreen
+import org.schabi.newpipe.core.ui.components.MainTab
 
 @Composable
 fun MainNavHost(navController: NavHostController = rememberNavController()) {
-    NavHost(navController, startDestination = "main") {
-        composable("main") {
-            MainScreen(onStreamSelected = { stream ->
-                navController.navigate("player/${stream.url}")
-            })
+    NavHost(navController, startDestination = MainTab.Trends.route) {
+        composable(MainTab.Trends.route) {
+            MainScreen(
+                onStreamSelected = { stream -> navController.navigate("player/${stream.url}") },
+                selectedTab = MainTab.Trends,
+                onTabSelected = { tab -> if (tab != MainTab.Trends) navController.navigate(tab.route) }
+            )
+        }
+        composable(MainTab.History.route) {
+            HistoryScreen(
+                onStreamSelected = { stream -> navController.navigate("player/${stream.url}") },
+                selectedTab = MainTab.History,
+                onTabSelected = { tab -> if (tab != MainTab.History) navController.navigate(tab.route) }
+            )
         }
         composable(
             route = "player/{url}",

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
@@ -9,11 +9,13 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
+import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
     private val player: ExoPlayer,
-    private val getStreamDetails: GetStreamDetailsUseCase
+    private val getStreamDetails: GetStreamDetailsUseCase,
+    private val addStreamToHistory: AddStreamToHistoryUseCase
 ) : ViewModel() {
 
     fun prepare(url: String) {
@@ -21,6 +23,7 @@ class PlayerViewModel @Inject constructor(
             val result = getStreamDetails(url).first()
             result.onSuccess {
                 player.setMediaItem(MediaItem.fromUri(it.url))
+                addStreamToHistory(it)
                 player.prepare()
             }
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,7 @@ include(":core:model")
 include(":core:domain")
 include(":feature:player")
 include(":feature:main")
+include(":feature:history")
 
 // Use a local copy of NewPipe Extractor by uncommenting the lines below.
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.


### PR DESCRIPTION
## Summary
- implement Room database and DAO for history
- expand history repository and add use cases
- update player to save streams to history
- add history feature module with UI
- add bottom navigation and history tab in main navigation

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842222da5a08322b65d8c922c62e078