### PR TITLE
Implement channel subscriptions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,4 +86,5 @@ dependencies {
     implementation(project(":feature:player"))
     implementation(project(":feature:main"))
     implementation(project(":feature:search"))
+    implementation(project(":feature:subscriptions"))
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -1,9 +1,18 @@
 package org.schabi.newpipe.core.data.db
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.AutoMigrationSpec
 
-@Database(entities = [HistoryEntryEntity::class], version = 1)
+@Database(
+    entities = [HistoryEntryEntity::class, SubscriptionEntity::class],
+    version = 2,
+    autoMigrations = [AutoMigration(from = 1, to = 2, spec = AppDatabase.Migration1To2::class)]
+)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao
+    abstract fun subscriptionDao(): SubscriptionDao
+
+    class Migration1To2 : AutoMigrationSpec
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/SubscriptionDao.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/SubscriptionDao.kt
@@ -1,0 +1,20 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Delete
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SubscriptionDao {
+    @Query("SELECT * FROM subscriptions")
+    fun getSubscriptions(): Flow<List<SubscriptionEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(subscription: SubscriptionEntity)
+
+    @Delete
+    suspend fun delete(subscription: SubscriptionEntity)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/SubscriptionEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/SubscriptionEntity.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "subscriptions")
+data class SubscriptionEntity(
+    @PrimaryKey val channelUrl: String,
+    val channelName: String,
+    val channelAvatarUrl: String?,
+    val subscriptionDate: Long
+)

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DataModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.components.SingletonComponent
 import org.schabi.newpipe.core.data.repository.HistoryRepository
 import org.schabi.newpipe.core.data.repository.PlaylistRepository
 import org.schabi.newpipe.core.data.repository.StreamRepository
+import org.schabi.newpipe.core.data.repository.SubscriptionRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultHistoryRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultPlaylistRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultStreamRepository
+import org.schabi.newpipe.core.data.repository.impl.DefaultSubscriptionRepository
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -22,4 +24,7 @@ abstract class DataModule {
 
     @Binds
     abstract fun bindHistoryRepository(impl: DefaultHistoryRepository): HistoryRepository
+
+    @Binds
+    abstract fun bindSubscriptionRepository(impl: DefaultSubscriptionRepository): SubscriptionRepository
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 import org.schabi.newpipe.core.data.db.AppDatabase
 import org.schabi.newpipe.core.data.db.HistoryDao
+import org.schabi.newpipe.core.data.db.SubscriptionDao
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -21,4 +22,7 @@ object DatabaseModule {
 
     @Provides
     fun provideHistoryDao(db: AppDatabase): HistoryDao = db.historyDao()
+
+    @Provides
+    fun provideSubscriptionDao(db: AppDatabase): SubscriptionDao = db.subscriptionDao()
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/SubscriptionRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/SubscriptionRepository.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.model.Channel
+
+interface SubscriptionRepository {
+    fun getSubscriptions(): Flow<List<Channel>>
+    suspend fun subscribe(channel: Channel)
+    suspend fun unsubscribe(channel: Channel)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultHistoryRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultHistoryRepository.kt
@@ -23,6 +23,7 @@ class DefaultHistoryRepository @Inject constructor(
             list.map { entity ->
                 Stream(
                     url = entity.streamUrl,
+                    channelUrl = null,
                     title = entity.title,
                     thumbnailUrl = entity.thumbnailUrl,
                     duration = 0L,

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultStreamRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultStreamRepository.kt
@@ -13,6 +13,7 @@ class DefaultStreamRepository : StreamRepository {
         val info = StreamInfo.getInfo(service, url)
         return Stream(
             url = info.url,
+            channelUrl = info.uploaderUrl,
             title = info.name,
             thumbnailUrl = info.thumbnailUrl,
             duration = info.duration,
@@ -29,6 +30,7 @@ class DefaultStreamRepository : StreamRepository {
         return searchInfo.relatedItems.map { item ->
             Stream(
                 url = item.url,
+                channelUrl = item.uploaderUrl,
                 title = item.name,
                 thumbnailUrl = item.thumbnailUrl,
                 duration = item.duration,
@@ -46,6 +48,7 @@ class DefaultStreamRepository : StreamRepository {
         return info.relatedItems.map { item ->
             Stream(
                 url = item.url,
+                channelUrl = item.uploaderUrl,
                 title = item.name,
                 thumbnailUrl = item.thumbnailUrl,
                 duration = item.duration,

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultSubscriptionRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultSubscriptionRepository.kt
@@ -1,0 +1,46 @@
+package org.schabi.newpipe.core.data.repository.impl
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.schabi.newpipe.core.data.db.SubscriptionDao
+import org.schabi.newpipe.core.data.db.SubscriptionEntity
+import org.schabi.newpipe.core.data.repository.SubscriptionRepository
+import org.schabi.newpipe.core.model.Channel
+import javax.inject.Inject
+
+class DefaultSubscriptionRepository @Inject constructor(
+    private val dao: SubscriptionDao
+) : SubscriptionRepository {
+    override fun getSubscriptions(): Flow<List<Channel>> =
+        dao.getSubscriptions().map { list ->
+            list.map { entity ->
+                Channel(
+                    url = entity.channelUrl,
+                    name = entity.channelName,
+                    avatarUrl = entity.channelAvatarUrl
+                )
+            }
+        }
+
+    override suspend fun subscribe(channel: Channel) {
+        dao.insert(
+            SubscriptionEntity(
+                channelUrl = channel.url,
+                channelName = channel.name,
+                channelAvatarUrl = channel.avatarUrl,
+                subscriptionDate = System.currentTimeMillis()
+            )
+        )
+    }
+
+    override suspend fun unsubscribe(channel: Channel) {
+        dao.delete(
+            SubscriptionEntity(
+                channelUrl = channel.url,
+                channelName = channel.name,
+                channelAvatarUrl = channel.avatarUrl,
+                subscriptionDate = 0L
+            )
+        )
+    }
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
@@ -6,11 +6,15 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.schabi.newpipe.core.data.repository.StreamRepository
 import org.schabi.newpipe.core.data.repository.HistoryRepository
+import org.schabi.newpipe.core.data.repository.SubscriptionRepository
 import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.GetSearchResultsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetTrendingStreamsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetWatchHistoryUseCase
+import org.schabi.newpipe.core.domain.usecase.SubscribeToChannelUseCase
+import org.schabi.newpipe.core.domain.usecase.GetSubscriptionsUseCase
+import org.schabi.newpipe.core.domain.usecase.UnsubscribeFromChannelUseCase
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -34,4 +38,16 @@ object DomainModule {
     @Provides
     fun provideAddStreamToHistoryUseCase(repository: HistoryRepository): AddStreamToHistoryUseCase =
         AddStreamToHistoryUseCase(repository)
+
+    @Provides
+    fun provideSubscribeToChannelUseCase(repository: SubscriptionRepository): SubscribeToChannelUseCase =
+        SubscribeToChannelUseCase(repository)
+
+    @Provides
+    fun provideGetSubscriptionsUseCase(repository: SubscriptionRepository): GetSubscriptionsUseCase =
+        GetSubscriptionsUseCase(repository)
+
+    @Provides
+    fun provideUnsubscribeFromChannelUseCase(repository: SubscriptionRepository): UnsubscribeFromChannelUseCase =
+        UnsubscribeFromChannelUseCase(repository)
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetSubscriptionsUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetSubscriptionsUseCase.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.data.repository.SubscriptionRepository
+import org.schabi.newpipe.core.model.Channel
+import javax.inject.Inject
+
+class GetSubscriptionsUseCase @Inject constructor(
+    private val repository: SubscriptionRepository
+) {
+    operator fun invoke(): Flow<List<Channel>> = repository.getSubscriptions()
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/SubscribeToChannelUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/SubscribeToChannelUseCase.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import org.schabi.newpipe.core.data.repository.SubscriptionRepository
+import org.schabi.newpipe.core.model.Channel
+import javax.inject.Inject
+
+class SubscribeToChannelUseCase @Inject constructor(
+    private val repository: SubscriptionRepository
+) {
+    suspend operator fun invoke(channel: Channel) = repository.subscribe(channel)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/UnsubscribeFromChannelUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/UnsubscribeFromChannelUseCase.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import org.schabi.newpipe.core.data.repository.SubscriptionRepository
+import org.schabi.newpipe.core.model.Channel
+import javax.inject.Inject
+
+class UnsubscribeFromChannelUseCase @Inject constructor(
+    private val repository: SubscriptionRepository
+) {
+    suspend operator fun invoke(channel: Channel) = repository.unsubscribe(channel)
+}

--- a/core/model/src/main/java/org/schabi/newpipe/core/model/Stream.kt
+++ b/core/model/src/main/java/org/schabi/newpipe/core/model/Stream.kt
@@ -2,6 +2,7 @@ package org.schabi.newpipe.core.model
 
 data class Stream(
     val url: String,
+    val channelUrl: String?,
     val title: String,
     val thumbnailUrl: String?,
     val duration: Long,

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
@@ -2,10 +2,12 @@ package org.schabi.newpipe.core.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Subscriptions
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.ui.graphics.vector.ImageVector
 
 enum class MainTab(val route: String, val label: String, val icon: ImageVector) {
     Trends("main", "Trends", Icons.Filled.Home),
-    History("history", "History", Icons.Filled.History)
+    History("history", "History", Icons.Filled.History),
+    Subscriptions("subscriptions", "Subscriptions", Icons.Filled.Subscriptions)
 }

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
@@ -12,6 +12,7 @@ import androidx.navigation.navArgument
 import androidx.navigation.NavType
 import org.schabi.newpipe.NewPlayerActivity
 import org.schabi.newpipe.feature.history.HistoryScreen
+import org.schabi.newpipe.feature.subscriptions.SubscriptionsScreen
 import org.schabi.newpipe.feature.search.SearchScreen
 import org.schabi.newpipe.core.ui.components.MainTab
 
@@ -31,6 +32,13 @@ fun MainNavHost(navController: NavHostController = rememberNavController()) {
                 onStreamSelected = { stream -> navController.navigate("player/${stream.url}") },
                 selectedTab = MainTab.History,
                 onTabSelected = { tab -> if (tab != MainTab.History) navController.navigate(tab.route) },
+                onSearchClicked = { navController.navigate("search") }
+            )
+        }
+        composable(MainTab.Subscriptions.route) {
+            SubscriptionsScreen(
+                selectedTab = MainTab.Subscriptions,
+                onTabSelected = { tab -> if (tab != MainTab.Subscriptions) navController.navigate(tab.route) },
                 onSearchClicked = { navController.navigate("search") }
             )
         }

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.feature.player
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,13 +22,17 @@ fun DefaultPlayerScreen(url: String, viewModel: PlayerViewModel = hiltViewModel(
     }
     val player = viewModel.getPlayer()
     DisposableEffect(Unit) {
-        onDispose {
-            player.release()
+        onDispose { player.release() }
+    }
+    Column(modifier = Modifier.fillMaxSize()) {
+        AndroidView(
+            modifier = Modifier.weight(1f),
+            factory = { context ->
+                PlayerView(context).apply { this.player = player }
+            }
+        )
+        Button(onClick = { viewModel.subscribeToCurrentChannel() }) {
+            Text("Subscribe")
         }
     }
-    AndroidView(modifier = Modifier.fillMaxSize(), factory = { context ->
-        PlayerView(context).apply {
-            this.player = player
-        }
-    })
 }

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
@@ -10,13 +10,18 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
 import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
+import org.schabi.newpipe.core.domain.usecase.SubscribeToChannelUseCase
+import org.schabi.newpipe.core.model.Channel
 
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
     private val player: ExoPlayer,
     private val getStreamDetails: GetStreamDetailsUseCase,
-    private val addStreamToHistory: AddStreamToHistoryUseCase
+    private val addStreamToHistory: AddStreamToHistoryUseCase,
+    private val subscribeToChannel: SubscribeToChannelUseCase
 ) : ViewModel() {
+
+    private var currentChannel: Channel? = null
 
     fun prepare(url: String) {
         viewModelScope.launch {
@@ -24,6 +29,11 @@ class PlayerViewModel @Inject constructor(
             result.onSuccess {
                 player.setMediaItem(MediaItem.fromUri(it.url))
                 addStreamToHistory(it)
+                currentChannel = Channel(
+                    url = it.channelUrl ?: it.uploader ?: it.url,
+                    name = it.uploader ?: "",
+                    avatarUrl = null
+                )
                 player.prepare()
             }
         }
@@ -39,4 +49,9 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun getPlayer(): ExoPlayer = player
+
+    fun subscribeToCurrentChannel() {
+        val channel = currentChannel ?: return
+        viewModelScope.launch { subscribeToChannel(channel) }
+    }
 }

--- a/feature/subscriptions/build.gradle.kts
+++ b/feature/subscriptions/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.main"
+    namespace = "org.schabi.newpipe.feature.subscriptions"
     defaultConfig { minSdk = 21 }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -22,13 +22,10 @@ android {
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
-    implementation(project(":feature:history"))
-    implementation(project(":feature:subscriptions"))
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")

--- a/feature/subscriptions/src/main/java/org/schabi/newpipe/feature/subscriptions/SubscriptionsScreen.kt
+++ b/feature/subscriptions/src/main/java/org/schabi/newpipe/feature/subscriptions/SubscriptionsScreen.kt
@@ -1,0 +1,63 @@
+package org.schabi.newpipe.feature.subscriptions
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import org.schabi.newpipe.core.model.Channel
+import org.schabi.newpipe.core.ui.components.MainNavigationBar
+import org.schabi.newpipe.core.ui.components.MainTab
+
+@Composable
+fun SubscriptionsScreen(
+    selectedTab: MainTab,
+    onTabSelected: (MainTab) -> Unit,
+    onSearchClicked: () -> Unit,
+    viewModel: SubscriptionsViewModel = hiltViewModel()
+) {
+    val subs = viewModel.subscriptions.collectAsState().value
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Subscriptions") },
+                actions = {
+                    IconButton(onClick = onSearchClicked) {
+                        Icon(Icons.Filled.Search, contentDescription = "Search")
+                    }
+                }
+            )
+        },
+        bottomBar = { MainNavigationBar(selectedTab, onTabSelected) }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            items(subs) { channel ->
+                ChannelRow(channel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChannelRow(channel: Channel) {
+    Row(modifier = Modifier.padding(8.dp)) {
+        AsyncImage(model = channel.avatarUrl, contentDescription = null)
+        Spacer(Modifier.width(8.dp))
+        Text(text = channel.name)
+    }
+}

--- a/feature/subscriptions/src/main/java/org/schabi/newpipe/feature/subscriptions/SubscriptionsViewModel.kt
+++ b/feature/subscriptions/src/main/java/org/schabi/newpipe/feature/subscriptions/SubscriptionsViewModel.kt
@@ -1,0 +1,20 @@
+package org.schabi.newpipe.feature.subscriptions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import org.schabi.newpipe.core.domain.usecase.GetSubscriptionsUseCase
+import org.schabi.newpipe.core.model.Channel
+
+@HiltViewModel
+class SubscriptionsViewModel @Inject constructor(
+    getSubscriptionsUseCase: GetSubscriptionsUseCase
+) : ViewModel() {
+    val subscriptions: StateFlow<List<Channel>> =
+        getSubscriptionsUseCase()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include(":feature:main")
 include(":feature:history")
 
 include(":feature:search")
+include(":feature:subscriptions")
 // Use a local copy of NewPipe Extractor by uncommenting the lines below.
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().


### PR DESCRIPTION
## Summary
- add `SubscriptionEntity` and related DAO
- upgrade `AppDatabase` to version 2 and expose new DAO
- add repository, use cases and DI wiring for channel subscriptions
- create `feature:subscriptions` module with basic UI
- integrate subscriptions tab into main navigation
- allow subscribing to channel from player screen
- extend `Stream` model with `channelUrl`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842295b5fa883229cb5a421fd08e58e