### PR TITLE
Implement local playlists

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,4 +86,5 @@ dependencies {
     implementation(project(":feature:player"))
     implementation(project(":feature:main"))
     implementation(project(":feature:search"))
+    implementation(project(":feature:playlists"))
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -1,9 +1,15 @@
 package org.schabi.newpipe.core.data.db
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [HistoryEntryEntity::class], version = 1)
+@Database(
+    entities = [HistoryEntryEntity::class, PlaylistEntity::class, PlaylistItemEntity::class],
+    version = 3,
+    autoMigrations = [AutoMigration(from = 2, to = 3)]
+)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao
+    abstract fun playlistDao(): PlaylistDao
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistDao.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistDao.kt
@@ -1,0 +1,28 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PlaylistDao {
+    @Query("SELECT * FROM playlists")
+    fun getPlaylists(): Flow<List<PlaylistEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlaylist(playlist: PlaylistEntity): Long
+
+    @Query("DELETE FROM playlists WHERE id = :id")
+    suspend fun deletePlaylist(id: Long)
+
+    @Query("SELECT * FROM playlist_items WHERE playlistId = :playlistId")
+    fun getPlaylistItems(playlistId: Long): Flow<List<PlaylistItemEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlaylistItem(item: PlaylistItemEntity)
+
+    @Query("DELETE FROM playlist_items WHERE id = :id")
+    suspend fun deletePlaylistItem(id: Long)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistEntity.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "playlists")
+data class PlaylistEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val thumbnailUrl: String?
+)

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistItemEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistItemEntity.kt
@@ -1,0 +1,27 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "playlist_items",
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaylistEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["playlistId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("playlistId")]
+)
+data class PlaylistItemEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val playlistId: Long,
+    val streamUrl: String,
+    val title: String,
+    val uploader: String?,
+    val thumbnailUrl: String?
+)

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 import org.schabi.newpipe.core.data.db.AppDatabase
 import org.schabi.newpipe.core.data.db.HistoryDao
+import org.schabi.newpipe.core.data.db.PlaylistDao
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -21,4 +22,7 @@ object DatabaseModule {
 
     @Provides
     fun provideHistoryDao(db: AppDatabase): HistoryDao = db.historyDao()
+
+    @Provides
+    fun providePlaylistDao(db: AppDatabase): PlaylistDao = db.playlistDao()
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/PlaylistRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/PlaylistRepository.kt
@@ -1,7 +1,14 @@
 package org.schabi.newpipe.core.data.repository
 
-import org.schabi.newpipe.core.model.Playlist
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.model.LocalPlaylist
+import org.schabi.newpipe.core.model.Stream
 
 interface PlaylistRepository {
-    suspend fun getPlaylist(url: String): Playlist
+    fun getPlaylists(): Flow<List<LocalPlaylist>>
+    suspend fun createPlaylist(name: String, thumbnailUrl: String? = null)
+    suspend fun deletePlaylist(id: Long)
+    fun getPlaylistItems(playlistId: Long): Flow<List<Stream>>
+    suspend fun addStreamToPlaylist(playlistId: Long, stream: Stream)
+    suspend fun removeStreamFromPlaylist(itemId: Long)
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultPlaylistRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultPlaylistRepository.kt
@@ -1,18 +1,59 @@
 package org.schabi.newpipe.core.data.repository.impl
 
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.schabi.newpipe.core.data.db.PlaylistDao
+import org.schabi.newpipe.core.data.db.PlaylistEntity
+import org.schabi.newpipe.core.data.db.PlaylistItemEntity
 import org.schabi.newpipe.core.data.repository.PlaylistRepository
-import org.schabi.newpipe.core.model.Playlist
-import org.schabi.newpipe.extractor.NewPipe
-import org.schabi.newpipe.extractor.playlist.PlaylistInfo
+import org.schabi.newpipe.core.model.LocalPlaylist
+import org.schabi.newpipe.core.model.Stream
 
-class DefaultPlaylistRepository : PlaylistRepository {
-    override suspend fun getPlaylist(url: String): Playlist {
-        val service = NewPipe.getServiceByUrl(url)
-        val info = PlaylistInfo.getInfo(service, url)
-        return Playlist(
-            url = info.url,
-            name = info.name,
-            thumbnailUrl = info.avatarUrl
+class DefaultPlaylistRepository @Inject constructor(
+    private val playlistDao: PlaylistDao
+) : PlaylistRepository {
+    override fun getPlaylists(): Flow<List<LocalPlaylist>> =
+        playlistDao.getPlaylists().map { list ->
+            list.map { entity ->
+                LocalPlaylist(id = entity.id, name = entity.name, thumbnailUrl = entity.thumbnailUrl)
+            }
+        }
+
+    override suspend fun createPlaylist(name: String, thumbnailUrl: String?) {
+        playlistDao.insertPlaylist(PlaylistEntity(name = name, thumbnailUrl = thumbnailUrl))
+    }
+
+    override suspend fun deletePlaylist(id: Long) {
+        playlistDao.deletePlaylist(id)
+    }
+
+    override fun getPlaylistItems(playlistId: Long): Flow<List<Stream>> =
+        playlistDao.getPlaylistItems(playlistId).map { list ->
+            list.map { item ->
+                Stream(
+                    url = item.streamUrl,
+                    title = item.title,
+                    thumbnailUrl = item.thumbnailUrl,
+                    duration = 0L,
+                    uploader = item.uploader
+                )
+            }
+        }
+
+    override suspend fun addStreamToPlaylist(playlistId: Long, stream: Stream) {
+        playlistDao.insertPlaylistItem(
+            PlaylistItemEntity(
+                playlistId = playlistId,
+                streamUrl = stream.url,
+                title = stream.title,
+                uploader = stream.uploader,
+                thumbnailUrl = stream.thumbnailUrl
+            )
         )
+    }
+
+    override suspend fun removeStreamFromPlaylist(itemId: Long) {
+        playlistDao.deletePlaylistItem(itemId)
     }
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
@@ -6,11 +6,17 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.schabi.newpipe.core.data.repository.StreamRepository
 import org.schabi.newpipe.core.data.repository.HistoryRepository
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
 import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.GetSearchResultsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetTrendingStreamsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetWatchHistoryUseCase
+import org.schabi.newpipe.core.domain.usecase.CreatePlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistsUseCase
+import org.schabi.newpipe.core.domain.usecase.AddStreamToPlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.DeletePlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistItemsUseCase
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -34,4 +40,24 @@ object DomainModule {
     @Provides
     fun provideAddStreamToHistoryUseCase(repository: HistoryRepository): AddStreamToHistoryUseCase =
         AddStreamToHistoryUseCase(repository)
+
+    @Provides
+    fun provideCreatePlaylistUseCase(repository: PlaylistRepository): CreatePlaylistUseCase =
+        CreatePlaylistUseCase(repository)
+
+    @Provides
+    fun provideGetPlaylistsUseCase(repository: PlaylistRepository): GetPlaylistsUseCase =
+        GetPlaylistsUseCase(repository)
+
+    @Provides
+    fun provideAddStreamToPlaylistUseCase(repository: PlaylistRepository): AddStreamToPlaylistUseCase =
+        AddStreamToPlaylistUseCase(repository)
+
+    @Provides
+    fun provideDeletePlaylistUseCase(repository: PlaylistRepository): DeletePlaylistUseCase =
+        DeletePlaylistUseCase(repository)
+
+    @Provides
+    fun provideGetPlaylistItemsUseCase(repository: PlaylistRepository): GetPlaylistItemsUseCase =
+        GetPlaylistItemsUseCase(repository)
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/AddStreamToPlaylistUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/AddStreamToPlaylistUseCase.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import javax.inject.Inject
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.model.Stream
+
+class AddStreamToPlaylistUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    suspend operator fun invoke(playlistId: Long, stream: Stream) =
+        repository.addStreamToPlaylist(playlistId, stream)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/CreatePlaylistUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/CreatePlaylistUseCase.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import javax.inject.Inject
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+
+class CreatePlaylistUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    suspend operator fun invoke(name: String, thumbnailUrl: String? = null) =
+        repository.createPlaylist(name, thumbnailUrl)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/DeletePlaylistUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/DeletePlaylistUseCase.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import javax.inject.Inject
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+
+class DeletePlaylistUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    suspend operator fun invoke(id: Long) = repository.deletePlaylist(id)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetPlaylistItemsUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetPlaylistItemsUseCase.kt
@@ -1,0 +1,13 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.model.Stream
+
+class GetPlaylistItemsUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    operator fun invoke(playlistId: Long): Flow<List<Stream>> =
+        repository.getPlaylistItems(playlistId)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetPlaylistsUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetPlaylistsUseCase.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.model.LocalPlaylist
+
+class GetPlaylistsUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    operator fun invoke(): Flow<List<LocalPlaylist>> = repository.getPlaylists()
+}

--- a/core/model/src/main/java/org/schabi/newpipe/core/model/LocalPlaylist.kt
+++ b/core/model/src/main/java/org/schabi/newpipe/core/model/LocalPlaylist.kt
@@ -1,0 +1,7 @@
+package org.schabi.newpipe.core.model
+
+data class LocalPlaylist(
+    val id: Long,
+    val name: String,
+    val thumbnailUrl: String?
+)

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
@@ -3,9 +3,11 @@ package org.schabi.newpipe.core.ui.components
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.PlaylistPlay
 import androidx.compose.ui.graphics.vector.ImageVector
 
 enum class MainTab(val route: String, val label: String, val icon: ImageVector) {
     Trends("main", "Trends", Icons.Filled.Home),
-    History("history", "History", Icons.Filled.History)
+    History("history", "History", Icons.Filled.History),
+    Playlists("playlists", "Playlists", Icons.Filled.PlaylistPlay)
 }

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
@@ -13,6 +13,8 @@ import androidx.navigation.NavType
 import org.schabi.newpipe.NewPlayerActivity
 import org.schabi.newpipe.feature.history.HistoryScreen
 import org.schabi.newpipe.feature.search.SearchScreen
+import org.schabi.newpipe.feature.playlists.PlaylistsScreen
+import org.schabi.newpipe.feature.playlists.PlaylistDetailScreen
 import org.schabi.newpipe.core.ui.components.MainTab
 
 @Composable
@@ -34,6 +36,13 @@ fun MainNavHost(navController: NavHostController = rememberNavController()) {
                 onSearchClicked = { navController.navigate("search") }
             )
         }
+        composable(MainTab.Playlists.route) {
+            PlaylistsScreen(
+                onPlaylistSelected = { playlist -> navController.navigate("playlist/${playlist.id}") },
+                selectedTab = MainTab.Playlists,
+                onTabSelected = { tab -> if (tab != MainTab.Playlists) navController.navigate(tab.route) }
+            )
+        }
         composable("search") {
             SearchScreen(onStreamSelected = { stream -> navController.navigate("player/${stream.url}") })
         }
@@ -49,6 +58,13 @@ fun MainNavHost(navController: NavHostController = rememberNavController()) {
                 })
                 navController.popBackStack()
             }
+        }
+        composable(
+            route = "playlist/{id}",
+            arguments = listOf(navArgument("id") { type = NavType.LongType })
+        ) { backStackEntry ->
+            val id = backStackEntry.arguments?.getLong("id") ?: return@composable
+            PlaylistDetailScreen(id)
         }
     }
 }

--- a/feature/playlists/build.gradle.kts
+++ b/feature/playlists/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.main"
+    namespace = "org.schabi.newpipe.feature.playlists"
     defaultConfig { minSdk = 21 }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -14,21 +14,16 @@ android {
     }
     kotlinOptions { jvmTarget = "17" }
     buildFeatures { compose = true }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String
-    }
+    composeOptions { kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String }
 }
 
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
-    implementation(project(":feature:history"))
-    implementation(project(":feature:playlists"))
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")

--- a/feature/playlists/src/main/java/org/schabi/newpipe/feature/playlists/PlaylistsScreen.kt
+++ b/feature/playlists/src/main/java/org/schabi/newpipe/feature/playlists/PlaylistsScreen.kt
@@ -1,0 +1,93 @@
+package org.schabi.newpipe.feature.playlists
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import org.schabi.newpipe.core.model.LocalPlaylist
+import org.schabi.newpipe.core.ui.components.MainNavigationBar
+import org.schabi.newpipe.core.ui.components.MainTab
+
+@Composable
+fun PlaylistsScreen(
+    onPlaylistSelected: (LocalPlaylist) -> Unit,
+    selectedTab: MainTab = MainTab.Playlists,
+    onTabSelected: (MainTab) -> Unit = {},
+    viewModel: PlaylistsViewModel = hiltViewModel()
+) {
+    val playlists = viewModel.playlists.collectAsState().value
+    var showDialog by remember { mutableStateOf(false) }
+    var playlistName by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Playlists") }) },
+        bottomBar = { MainNavigationBar(selectedTab, onTabSelected) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showDialog = true }) {
+                Icon(Icons.Filled.Add, contentDescription = "Add")
+            }
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            items(playlists) { playlist ->
+                Text(
+                    text = playlist.name,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                        .clickable { onPlaylistSelected(playlist) }
+                )
+            }
+        }
+    }
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.create(playlistName)
+                    playlistName = ""
+                    showDialog = false
+                }) {
+                    Text("Create")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+            },
+            title = { Text("New Playlist") },
+            text = {
+                OutlinedTextField(
+                    value = playlistName,
+                    onValueChange = { playlistName = it },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        )
+    }
+}
+
+@Composable
+fun PlaylistDetailScreen(id: Long) {
+    Scaffold { padding ->
+        Column(Modifier.fillMaxSize().padding(padding)) {
+            Text("Playlist #$id")
+        }
+    }
+}

--- a/feature/playlists/src/main/java/org/schabi/newpipe/feature/playlists/PlaylistsViewModel.kt
+++ b/feature/playlists/src/main/java/org/schabi/newpipe/feature/playlists/PlaylistsViewModel.kt
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.feature.playlists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.schabi.newpipe.core.domain.usecase.CreatePlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistsUseCase
+import org.schabi.newpipe.core.model.LocalPlaylist
+
+@HiltViewModel
+class PlaylistsViewModel @Inject constructor(
+    private val getPlaylists: GetPlaylistsUseCase,
+    private val createPlaylist: CreatePlaylistUseCase
+) : ViewModel() {
+    val playlists: StateFlow<List<LocalPlaylist>> =
+        getPlaylists().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun create(name: String) {
+        viewModelScope.launch { createPlaylist(name) }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include(":feature:main")
 include(":feature:history")
 
 include(":feature:search")
+include(":feature:playlists")
 // Use a local copy of NewPipe Extractor by uncommenting the lines below.
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().


### PR DESCRIPTION
## Summary
- bump Room database version to 3 and add playlist tables
- implement DAO/repository for local playlists
- expose playlist use cases from domain layer
- add new Playlists feature module with screen and view model
- wire Playlists tab into main navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422b1374f88322af8b103005de9a7b