### PR TITLE
Modern settings screen using Compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,4 +86,5 @@ dependencies {
     implementation(project(":feature:player"))
     implementation(project(":feature:main"))
     implementation(project(":feature:search"))
+    implementation(project(":feature:settings"))
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,10 +79,6 @@
             android:label="@string/title_activity_play_queue"
             android:launchMode="singleTask" />
 
-        <activity
-            android:name=".settings.SettingsActivity"
-            android:exported="false"
-            android:label="@string/settings" />
 
         <activity
             android:name=".about.AboutActivity"

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -63,7 +63,6 @@ import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
-import org.schabi.newpipe.settings.SettingsActivity;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.util.List;
@@ -653,10 +652,6 @@ public final class NavigationHelper {
         context.startActivity(intent);
     }
 
-    public static void openSettings(final Context context) {
-        final Intent intent = new Intent(context, SettingsActivity.class);
-        context.startActivity(intent);
-    }
 
     public static void openDownloads(final Activity activity) {
         if (PermissionHelper.checkStoragePermissions(

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/PreferencesModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/PreferencesModule.kt
@@ -1,0 +1,19 @@
+package org.schabi.newpipe.core.data.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import org.schabi.newpipe.core.data.preferences.PreferenceDataStore
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PreferencesModule {
+    @Provides
+    @Singleton
+    fun providePreferenceDataStore(@ApplicationContext context: Context): PreferenceDataStore =
+        PreferenceDataStore(context)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/preferences/PreferenceDataStore.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/preferences/PreferenceDataStore.kt
@@ -3,6 +3,7 @@ package org.schabi.newpipe.core.data.preferences
 import android.content.Context
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -12,11 +13,27 @@ class PreferenceDataStore(private val context: Context) {
     private val Context.dataStore by preferencesDataStore(name = "settings")
 
     private val watchHistoryKey = booleanPreferencesKey("enable_watch_history")
+    private val themeKey = stringPreferencesKey("selected_theme")
+    private val resolutionKey = stringPreferencesKey("default_resolution")
 
     val isWatchHistoryEnabled: Flow<Boolean> =
         context.dataStore.data.map { it[watchHistoryKey] ?: false }
 
+    val selectedTheme: Flow<String> =
+        context.dataStore.data.map { it[themeKey] ?: "system" }
+
+    val defaultResolution: Flow<String> =
+        context.dataStore.data.map { it[resolutionKey] ?: "best" }
+
     suspend fun setWatchHistoryEnabled(enabled: Boolean) {
         context.dataStore.edit { it[watchHistoryKey] = enabled }
+    }
+
+    suspend fun setSelectedTheme(theme: String) {
+        context.dataStore.edit { it[themeKey] = theme }
+    }
+
+    suspend fun setDefaultResolution(resolution: String) {
+        context.dataStore.edit { it[resolutionKey] = resolution }
     }
 }

--- a/feature/history/src/main/java/org/schabi/newpipe/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/java/org/schabi/newpipe/feature/history/HistoryScreen.kt
@@ -6,13 +6,18 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import org.schabi.newpipe.core.model.Stream
@@ -26,6 +31,7 @@ fun HistoryScreen(
     selectedTab: MainTab,
     onTabSelected: (MainTab) -> Unit,
     onSearchClicked: () -> Unit,
+    onSettingsClicked: () -> Unit,
     viewModel: HistoryViewModel = hiltViewModel()
 ) {
     val history = viewModel.history.collectAsState().value
@@ -36,6 +42,16 @@ fun HistoryScreen(
                 actions = {
                     IconButton(onClick = onSearchClicked) {
                         Icon(Icons.Filled.Search, contentDescription = "Search")
+                    }
+                    var menuExpanded by remember { mutableStateOf(false) }
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(Icons.Filled.MoreVert, contentDescription = "Menu")
+                    }
+                    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                        DropdownMenuItem(text = { Text("Settings") }, onClick = {
+                            menuExpanded = false
+                            onSettingsClicked()
+                        })
                     }
                 }
             )

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavType
 import org.schabi.newpipe.NewPlayerActivity
 import org.schabi.newpipe.feature.history.HistoryScreen
 import org.schabi.newpipe.feature.search.SearchScreen
+import org.schabi.newpipe.feature.settings.SettingsScreen
 import org.schabi.newpipe.core.ui.components.MainTab
 
 @Composable
@@ -23,7 +24,8 @@ fun MainNavHost(navController: NavHostController = rememberNavController()) {
                 onStreamSelected = { stream -> navController.navigate("player/${stream.url}") },
                 selectedTab = MainTab.Trends,
                 onTabSelected = { tab -> if (tab != MainTab.Trends) navController.navigate(tab.route) },
-                onSearchClicked = { navController.navigate("search") }
+                onSearchClicked = { navController.navigate("search") },
+                onSettingsClicked = { navController.navigate("settings") }
             )
         }
         composable(MainTab.History.route) {
@@ -31,11 +33,15 @@ fun MainNavHost(navController: NavHostController = rememberNavController()) {
                 onStreamSelected = { stream -> navController.navigate("player/${stream.url}") },
                 selectedTab = MainTab.History,
                 onTabSelected = { tab -> if (tab != MainTab.History) navController.navigate(tab.route) },
-                onSearchClicked = { navController.navigate("search") }
+                onSearchClicked = { navController.navigate("search") },
+                onSettingsClicked = { navController.navigate("settings") }
             )
         }
         composable("search") {
             SearchScreen(onStreamSelected = { stream -> navController.navigate("player/${stream.url}") })
+        }
+        composable("settings") {
+            SettingsScreen(onNavigateUp = { navController.popBackStack() })
         }
         composable(
             route = "player/{url}",

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainScreen.kt
@@ -6,13 +6,18 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import org.schabi.newpipe.core.model.Stream
@@ -26,6 +31,7 @@ fun MainScreen(
     selectedTab: MainTab,
     onTabSelected: (MainTab) -> Unit,
     onSearchClicked: () -> Unit,
+    onSettingsClicked: () -> Unit,
     viewModel: MainViewModel = hiltViewModel()
 ) {
     val state = viewModel.uiState.collectAsState().value
@@ -36,6 +42,16 @@ fun MainScreen(
                 actions = {
                     IconButton(onClick = onSearchClicked) {
                         Icon(Icons.Filled.Search, contentDescription = "Search")
+                    }
+                    var menuExpanded by remember { mutableStateOf(false) }
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(Icons.Filled.MoreVert, contentDescription = "Menu")
+                    }
+                    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                        DropdownMenuItem(text = { Text("Settings") }, onClick = {
+                            menuExpanded = false
+                            onSettingsClicked()
+                        })
                     }
                 }
             )

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.main"
+    namespace = "org.schabi.newpipe.feature.settings"
     defaultConfig { minSdk = 21 }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -21,15 +21,13 @@ android {
 
 dependencies {
     implementation(project(":core:ui"))
-    implementation(project(":core:domain"))
-    implementation(project(":feature:history"))
-    implementation(project(":feature:settings"))
-    implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
+    implementation(project(":core:data"))
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.runtime:runtime")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
 }

--- a/feature/settings/src/main/java/org/schabi/newpipe/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/org/schabi/newpipe/feature/settings/SettingsScreen.kt
@@ -1,0 +1,95 @@
+package org.schabi.newpipe.feature.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun SettingsScreen(
+    onNavigateUp: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsState()
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Settings") }, navigationIcon = {
+                IconButton(onClick = onNavigateUp) {
+                    Icon(Icons.Filled.ArrowBack, contentDescription = null)
+                }
+            })
+        }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).padding(16.dp)) {
+            Text("Appearance")
+            var themeMenu by remember { mutableStateOf(false) }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { themeMenu = true }
+                    .padding(vertical = 12.dp)
+            ) {
+                Text("Theme: ${'$'}{state.selectedTheme}")
+            }
+            DropdownMenu(expanded = themeMenu, onDismissRequest = { themeMenu = false }) {
+                listOf("light", "dark", "system").forEach { theme ->
+                    DropdownMenuItem(text = { Text(theme) }, onClick = {
+                        themeMenu = false
+                        viewModel.setTheme(theme)
+                    })
+                }
+            }
+            Divider(modifier = Modifier.padding(vertical = 8.dp))
+            Text("Content")
+            var resMenu by remember { mutableStateOf(false) }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { resMenu = true }
+                    .padding(vertical = 12.dp)
+            ) {
+                Text("Default resolution: ${'$'}{state.defaultResolution}")
+            }
+            DropdownMenu(expanded = resMenu, onDismissRequest = { resMenu = false }) {
+                listOf("best", "720p", "1080p").forEach { res ->
+                    DropdownMenuItem(text = { Text(res) }, onClick = {
+                        resMenu = false
+                        viewModel.setDefaultResolution(res)
+                    })
+                }
+            }
+            Divider(modifier = Modifier.padding(vertical = 8.dp))
+            Text("History")
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp)
+            ) {
+                Text("Enable watch history", modifier = Modifier.weight(1f))
+                Switch(checked = state.watchHistoryEnabled, onCheckedChange = {
+                    viewModel.setWatchHistoryEnabled(it)
+                })
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/java/org/schabi/newpipe/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/org/schabi/newpipe/feature/settings/SettingsViewModel.kt
@@ -1,0 +1,47 @@
+package org.schabi.newpipe.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.schabi.newpipe.core.data.preferences.PreferenceDataStore
+import org.schabi.newpipe.core.data.repository.HistoryRepository
+
+data class SettingsUiState(
+    val watchHistoryEnabled: Boolean = false,
+    val selectedTheme: String = "system",
+    val defaultResolution: String = "best"
+)
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val prefs: PreferenceDataStore,
+    private val historyRepository: HistoryRepository
+) : ViewModel() {
+
+    val uiState: StateFlow<SettingsUiState> =
+        prefs.isWatchHistoryEnabled.map { enabled ->
+            SettingsUiState(
+                watchHistoryEnabled = enabled,
+                selectedTheme = "system",
+                defaultResolution = "best"
+            )
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState())
+
+    fun setWatchHistoryEnabled(enabled: Boolean) {
+        viewModelScope.launch { historyRepository.setWatchHistoryEnabled(enabled) }
+    }
+
+    fun setTheme(theme: String) {
+        viewModelScope.launch { prefs.setSelectedTheme(theme) }
+    }
+
+    fun setDefaultResolution(resolution: String) {
+        viewModelScope.launch { prefs.setDefaultResolution(resolution) }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include(":feature:main")
 include(":feature:history")
 
 include(":feature:search")
+include(":feature:settings")
 // Use a local copy of NewPipe Extractor by uncommenting the lines below.
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().


### PR DESCRIPTION
## Summary
- extend `PreferenceDataStore` to store theme and resolution
- provide `PreferenceDataStore` via new `PreferencesModule`
- create `feature:settings` with ViewModel and composable UI
- add overflow menu to open the Settings screen
- wire navigation to the new screen
- clean up `NavigationHelper`

## Testing
- `./gradlew test -q --console=plain` *(fails: SDK location not found)*
- `./gradlew assembleDebug -q --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422b1d43fc832281362201e7911bec