### PR TITLE
Implement local playlists feature

### DIFF
--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -6,13 +6,23 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.AutoMigrationSpec
 
 @Database(
-    entities = [HistoryEntryEntity::class, SubscriptionEntity::class],
-    version = 2,
-    autoMigrations = [AutoMigration(from = 1, to = 2, spec = AppDatabase.Migration1To2::class)]
+    entities = [
+        HistoryEntryEntity::class,
+        SubscriptionEntity::class,
+        PlaylistEntity::class,
+        PlaylistItemEntity::class
+    ],
+    version = 3,
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2, spec = AppDatabase.Migration1To2::class),
+        AutoMigration(from = 2, to = 3, spec = AppDatabase.Migration2To3::class)
+    ]
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao
     abstract fun subscriptionDao(): SubscriptionDao
+    abstract fun playlistDao(): PlaylistDao
 
     class Migration1To2 : AutoMigrationSpec
+    class Migration2To3 : AutoMigrationSpec
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistDao.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistDao.kt
@@ -1,0 +1,29 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PlaylistDao {
+    @Query("SELECT * FROM playlists")
+    fun getPlaylists(): Flow<List<PlaylistEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlaylist(entity: PlaylistEntity): Long
+
+    @Delete
+    suspend fun deletePlaylist(entity: PlaylistEntity)
+
+    @Query("SELECT * FROM playlist_items WHERE playlistId = :playlistId")
+    fun getItems(playlistId: Long): Flow<List<PlaylistItemEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertItem(entity: PlaylistItemEntity)
+
+    @Delete
+    suspend fun deleteItem(entity: PlaylistItemEntity)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistEntity.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "playlists")
+data class PlaylistEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val thumbnailUrl: String?
+)

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistItemEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistItemEntity.kt
@@ -1,0 +1,28 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import androidx.room.ForeignKey.CASCADE
+
+@Entity(
+    tableName = "playlist_items",
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaylistEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["playlistId"],
+            onDelete = CASCADE
+        )
+    ],
+    indices = [Index("playlistId")]
+)
+data class PlaylistItemEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val playlistId: Long,
+    val streamUrl: String,
+    val title: String,
+    val thumbnailUrl: String?,
+    val uploader: String?
+)

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
@@ -11,6 +11,7 @@ import javax.inject.Singleton
 import org.schabi.newpipe.core.data.db.AppDatabase
 import org.schabi.newpipe.core.data.db.HistoryDao
 import org.schabi.newpipe.core.data.db.SubscriptionDao
+import org.schabi.newpipe.core.data.db.PlaylistDao
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -25,4 +26,7 @@ object DatabaseModule {
 
     @Provides
     fun provideSubscriptionDao(db: AppDatabase): SubscriptionDao = db.subscriptionDao()
+
+    @Provides
+    fun providePlaylistDao(db: AppDatabase): PlaylistDao = db.playlistDao()
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/PlaylistRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/PlaylistRepository.kt
@@ -1,7 +1,14 @@
 package org.schabi.newpipe.core.data.repository
 
-import org.schabi.newpipe.core.model.Playlist
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.model.LocalPlaylist
+import org.schabi.newpipe.core.model.Stream
 
 interface PlaylistRepository {
-    suspend fun getPlaylist(url: String): Playlist
+    fun getPlaylists(): Flow<List<LocalPlaylist>>
+    suspend fun createPlaylist(name: String, thumbnailUrl: String? = null): Long
+    suspend fun deletePlaylist(id: Long)
+    fun getPlaylistItems(playlistId: Long): Flow<List<Stream>>
+    suspend fun addStreamToPlaylist(playlistId: Long, stream: Stream)
+    suspend fun removeStreamFromPlaylist(playlistId: Long, streamUrl: String)
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultPlaylistRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultPlaylistRepository.kt
@@ -1,18 +1,72 @@
 package org.schabi.newpipe.core.data.repository.impl
 
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.schabi.newpipe.core.data.db.PlaylistDao
+import org.schabi.newpipe.core.data.db.PlaylistEntity
+import org.schabi.newpipe.core.data.db.PlaylistItemEntity
 import org.schabi.newpipe.core.data.repository.PlaylistRepository
-import org.schabi.newpipe.core.model.Playlist
-import org.schabi.newpipe.extractor.NewPipe
-import org.schabi.newpipe.extractor.playlist.PlaylistInfo
+import org.schabi.newpipe.core.model.LocalPlaylist
+import org.schabi.newpipe.core.model.Stream
 
-class DefaultPlaylistRepository : PlaylistRepository {
-    override suspend fun getPlaylist(url: String): Playlist {
-        val service = NewPipe.getServiceByUrl(url)
-        val info = PlaylistInfo.getInfo(service, url)
-        return Playlist(
-            url = info.url,
-            name = info.name,
-            thumbnailUrl = info.avatarUrl
+class DefaultPlaylistRepository @Inject constructor(
+    private val dao: PlaylistDao
+) : PlaylistRepository {
+    override fun getPlaylists(): Flow<List<LocalPlaylist>> =
+        dao.getPlaylists().map { list ->
+            list.map { entity ->
+                LocalPlaylist(
+                    id = entity.id,
+                    name = entity.name,
+                    thumbnailUrl = entity.thumbnailUrl
+                )
+            }
+        }
+
+    override suspend fun createPlaylist(name: String, thumbnailUrl: String?): Long =
+        dao.insertPlaylist(PlaylistEntity(name = name, thumbnailUrl = thumbnailUrl))
+
+    override suspend fun deletePlaylist(id: Long) {
+        dao.deletePlaylist(PlaylistEntity(id = id, name = "", thumbnailUrl = null))
+    }
+
+    override fun getPlaylistItems(playlistId: Long): Flow<List<Stream>> =
+        dao.getItems(playlistId).map { list ->
+            list.map { entity ->
+                Stream(
+                    url = entity.streamUrl,
+                    channelUrl = null,
+                    title = entity.title,
+                    thumbnailUrl = entity.thumbnailUrl,
+                    duration = 0L,
+                    uploader = entity.uploader
+                )
+            }
+        }
+
+    override suspend fun addStreamToPlaylist(playlistId: Long, stream: Stream) {
+        dao.insertItem(
+            PlaylistItemEntity(
+                playlistId = playlistId,
+                streamUrl = stream.url,
+                title = stream.title,
+                thumbnailUrl = stream.thumbnailUrl,
+                uploader = stream.uploader
+            )
+        )
+    }
+
+    override suspend fun removeStreamFromPlaylist(playlistId: Long, streamUrl: String) {
+        dao.deleteItem(
+            PlaylistItemEntity(
+                id = 0,
+                playlistId = playlistId,
+                streamUrl = streamUrl,
+                title = "",
+                thumbnailUrl = null,
+                uploader = null
+            )
         )
     }
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import org.schabi.newpipe.core.data.repository.StreamRepository
 import org.schabi.newpipe.core.data.repository.HistoryRepository
 import org.schabi.newpipe.core.data.repository.SubscriptionRepository
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
 import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.GetSearchResultsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
@@ -15,6 +16,12 @@ import org.schabi.newpipe.core.domain.usecase.GetWatchHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.SubscribeToChannelUseCase
 import org.schabi.newpipe.core.domain.usecase.GetSubscriptionsUseCase
 import org.schabi.newpipe.core.domain.usecase.UnsubscribeFromChannelUseCase
+import org.schabi.newpipe.core.domain.usecase.CreatePlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistsUseCase
+import org.schabi.newpipe.core.domain.usecase.AddStreamToPlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistItemsUseCase
+import org.schabi.newpipe.core.domain.usecase.RemoveStreamFromPlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.DeletePlaylistUseCase
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -50,4 +57,28 @@ object DomainModule {
     @Provides
     fun provideUnsubscribeFromChannelUseCase(repository: SubscriptionRepository): UnsubscribeFromChannelUseCase =
         UnsubscribeFromChannelUseCase(repository)
+
+    @Provides
+    fun provideCreatePlaylistUseCase(repository: PlaylistRepository): CreatePlaylistUseCase =
+        CreatePlaylistUseCase(repository)
+
+    @Provides
+    fun provideGetPlaylistsUseCase(repository: PlaylistRepository): GetPlaylistsUseCase =
+        GetPlaylistsUseCase(repository)
+
+    @Provides
+    fun provideAddStreamToPlaylistUseCase(repository: PlaylistRepository): AddStreamToPlaylistUseCase =
+        AddStreamToPlaylistUseCase(repository)
+
+    @Provides
+    fun provideGetPlaylistItemsUseCase(repository: PlaylistRepository): GetPlaylistItemsUseCase =
+        GetPlaylistItemsUseCase(repository)
+
+    @Provides
+    fun provideRemoveStreamFromPlaylistUseCase(repository: PlaylistRepository): RemoveStreamFromPlaylistUseCase =
+        RemoveStreamFromPlaylistUseCase(repository)
+
+    @Provides
+    fun provideDeletePlaylistUseCase(repository: PlaylistRepository): DeletePlaylistUseCase =
+        DeletePlaylistUseCase(repository)
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/AddStreamToPlaylistUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/AddStreamToPlaylistUseCase.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.model.Stream
+import javax.inject.Inject
+
+class AddStreamToPlaylistUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    suspend operator fun invoke(playlistId: Long, stream: Stream) =
+        repository.addStreamToPlaylist(playlistId, stream)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/CreatePlaylistUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/CreatePlaylistUseCase.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import javax.inject.Inject
+
+class CreatePlaylistUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    suspend operator fun invoke(name: String) = repository.createPlaylist(name)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/DeletePlaylistUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/DeletePlaylistUseCase.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import javax.inject.Inject
+
+class DeletePlaylistUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    suspend operator fun invoke(id: Long) = repository.deletePlaylist(id)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetPlaylistItemsUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetPlaylistItemsUseCase.kt
@@ -1,0 +1,13 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.model.Stream
+import javax.inject.Inject
+
+class GetPlaylistItemsUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    operator fun invoke(playlistId: Long): Flow<List<Stream>> =
+        repository.getPlaylistItems(playlistId)
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetPlaylistsUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetPlaylistsUseCase.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.model.LocalPlaylist
+import javax.inject.Inject
+
+class GetPlaylistsUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    operator fun invoke(): Flow<List<LocalPlaylist>> = repository.getPlaylists()
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/RemoveStreamFromPlaylistUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/RemoveStreamFromPlaylistUseCase.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import javax.inject.Inject
+
+class RemoveStreamFromPlaylistUseCase @Inject constructor(
+    private val repository: PlaylistRepository
+) {
+    suspend operator fun invoke(playlistId: Long, streamUrl: String) =
+        repository.removeStreamFromPlaylist(playlistId, streamUrl)
+}

--- a/core/model/src/main/java/org/schabi/newpipe/core/model/LocalPlaylist.kt
+++ b/core/model/src/main/java/org/schabi/newpipe/core/model/LocalPlaylist.kt
@@ -1,0 +1,7 @@
+package org.schabi.newpipe.core.model
+
+data class LocalPlaylist(
+    val id: Long,
+    val name: String,
+    val thumbnailUrl: String?
+)

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
@@ -4,10 +4,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Subscriptions
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.PlaylistPlay
 import androidx.compose.ui.graphics.vector.ImageVector
 
 enum class MainTab(val route: String, val label: String, val icon: ImageVector) {
     Trends("main", "Trends", Icons.Filled.Home),
     History("history", "History", Icons.Filled.History),
-    Subscriptions("subscriptions", "Subscriptions", Icons.Filled.Subscriptions)
+    Subscriptions("subscriptions", "Subscriptions", Icons.Filled.Subscriptions),
+    Playlists("playlists", "Playlists", Icons.Filled.PlaylistPlay)
 }

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavType
 import org.schabi.newpipe.NewPlayerActivity
 import org.schabi.newpipe.feature.history.HistoryScreen
 import org.schabi.newpipe.feature.subscriptions.SubscriptionsScreen
+import org.schabi.newpipe.feature.playlists.PlaylistsScreen
 import org.schabi.newpipe.feature.search.SearchScreen
 import org.schabi.newpipe.core.ui.components.MainTab
 
@@ -39,6 +40,13 @@ fun MainNavHost(navController: NavHostController = rememberNavController()) {
             SubscriptionsScreen(
                 selectedTab = MainTab.Subscriptions,
                 onTabSelected = { tab -> if (tab != MainTab.Subscriptions) navController.navigate(tab.route) },
+                onSearchClicked = { navController.navigate("search") }
+            )
+        }
+        composable(MainTab.Playlists.route) {
+            PlaylistsScreen(
+                selectedTab = MainTab.Playlists,
+                onTabSelected = { tab -> if (tab != MainTab.Playlists) navController.navigate(tab.route) },
                 onSearchClicked = { navController.navigate("search") }
             )
         }

--- a/feature/playlists/build.gradle.kts
+++ b/feature/playlists/build.gradle.kts
@@ -6,30 +6,21 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.main"
+    namespace = "org.schabi.newpipe.feature.playlists"
     defaultConfig { minSdk = 21 }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+    compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }
     kotlinOptions { jvmTarget = "17" }
     buildFeatures { compose = true }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String
-    }
+    composeOptions { kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String }
 }
 
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
-    implementation(project(":feature:history"))
-    implementation(project(":feature:subscriptions"))
-    implementation(project(":feature:playlists"))
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")

--- a/feature/playlists/src/main/java/org/schabi/newpipe/feature/playlists/PlaylistsScreen.kt
+++ b/feature/playlists/src/main/java/org/schabi/newpipe/feature/playlists/PlaylistsScreen.kt
@@ -1,0 +1,94 @@
+package org.schabi.newpipe.feature.playlists
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import org.schabi.newpipe.core.ui.components.MainNavigationBar
+import org.schabi.newpipe.core.ui.components.MainTab
+import org.schabi.newpipe.core.model.LocalPlaylist
+
+@Composable
+fun PlaylistsScreen(
+    selectedTab: MainTab,
+    onTabSelected: (MainTab) -> Unit,
+    onSearchClicked: () -> Unit,
+    onPlaylistSelected: (LocalPlaylist) -> Unit = {},
+    viewModel: PlaylistsViewModel = hiltViewModel()
+) {
+    val playlists = viewModel.playlists.collectAsState().value
+    val showDialog = remember { mutableStateOf(false) }
+    val newName = remember { mutableStateOf("") }
+
+    if (showDialog.value) {
+        AlertDialog(
+            onDismissRequest = { showDialog.value = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.create(newName.value)
+                    showDialog.value = false
+                }) { Text("Create") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog.value = false }) { Text("Cancel") }
+            },
+            text = {
+                Column {
+                    Text(text = "New Playlist")
+                    OutlinedTextField(value = newName.value, onValueChange = { newName.value = it })
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Playlists") },
+                actions = {
+                    IconButton(onClick = onSearchClicked) {
+                        Icon(Icons.Filled.Search, contentDescription = "Search")
+                    }
+                }
+            )
+        },
+        bottomBar = { MainNavigationBar(selectedTab, onTabSelected) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showDialog.value = true }) {
+                Icon(Icons.Filled.Add, contentDescription = "Add")
+            }
+        }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            items(playlists) { playlist ->
+                Text(
+                    text = playlist.name,
+                    modifier = Modifier
+                        .clickable { onPlaylistSelected(playlist) }
+                        .padding(16.dp)
+                )
+            }
+        }
+    }
+}

--- a/feature/playlists/src/main/java/org/schabi/newpipe/feature/playlists/PlaylistsViewModel.kt
+++ b/feature/playlists/src/main/java/org/schabi/newpipe/feature/playlists/PlaylistsViewModel.kt
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.feature.playlists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.schabi.newpipe.core.domain.usecase.CreatePlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistsUseCase
+import org.schabi.newpipe.core.model.LocalPlaylist
+
+@HiltViewModel
+class PlaylistsViewModel @Inject constructor(
+    private val getPlaylists: GetPlaylistsUseCase,
+    private val createPlaylist: CreatePlaylistUseCase
+) : ViewModel() {
+    val playlists: StateFlow<List<LocalPlaylist>> =
+        getPlaylists().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun create(name: String) {
+        viewModelScope.launch { createPlaylist(name) }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ include(":feature:history")
 
 include(":feature:search")
 include(":feature:subscriptions")
+include(":feature:playlists")
 // Use a local copy of NewPipe Extractor by uncommenting the lines below.
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().


### PR DESCRIPTION
## Summary
- create `PlaylistEntity` and `PlaylistItemEntity` in database
- add `PlaylistDao` and hook it into `AppDatabase`
- provide `PlaylistRepository` and implementation for local playlists
- add playlist-related use-cases and DI
- introduce `LocalPlaylist` model
- create new `feature:playlists` module with UI and ViewModel
- extend navigation and bottom bar with a Playlists tab

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_68422dcf1a608322aaab1b117d27ae84