### PR TITLE
Add feed feature and playlist integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
     implementation(project(":feature:player"))
+    implementation(project(":feature:feed"))
     implementation(project(":feature:main"))
     implementation(project(":feature:search"))
     implementation(project(":feature:subscriptions"))

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -10,19 +10,23 @@ import androidx.room.migration.AutoMigrationSpec
         HistoryEntryEntity::class,
         SubscriptionEntity::class,
         PlaylistEntity::class,
-        PlaylistItemEntity::class
+        PlaylistItemEntity::class,
+        FeedItemEntity::class
     ],
-    version = 3,
+    version = 4,
     autoMigrations = [
         AutoMigration(from = 1, to = 2, spec = AppDatabase.Migration1To2::class),
-        AutoMigration(from = 2, to = 3, spec = AppDatabase.Migration2To3::class)
+        AutoMigration(from = 2, to = 3, spec = AppDatabase.Migration2To3::class),
+        AutoMigration(from = 3, to = 4, spec = AppDatabase.Migration3To4::class)
     ]
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao
     abstract fun subscriptionDao(): SubscriptionDao
     abstract fun playlistDao(): PlaylistDao
+    abstract fun feedDao(): FeedDao
 
     class Migration1To2 : AutoMigrationSpec
     class Migration2To3 : AutoMigrationSpec
+    class Migration3To4 : AutoMigrationSpec
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/FeedDao.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/FeedDao.kt
@@ -1,0 +1,27 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FeedDao {
+    @Query("SELECT * FROM feed_items ORDER BY uploadDate DESC")
+    fun getFeed(): Flow<List<FeedItemEntity>>
+
+    @Query("DELETE FROM feed_items")
+    suspend fun clear()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(items: List<FeedItemEntity>)
+
+    @Transaction
+    suspend fun replaceAll(items: List<FeedItemEntity>) {
+        clear()
+        insertAll(items)
+    }
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/FeedItemEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/FeedItemEntity.kt
@@ -1,0 +1,14 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "feed_items")
+data class FeedItemEntity(
+    @PrimaryKey val streamUrl: String,
+    val channelName: String,
+    val channelAvatarUrl: String?,
+    val uploadDate: Long?,
+    val title: String,
+    val thumbnailUrl: String?
+)

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DataModule.kt
@@ -6,12 +6,14 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.schabi.newpipe.core.data.repository.HistoryRepository
 import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.data.repository.FeedRepository
 import org.schabi.newpipe.core.data.repository.StreamRepository
 import org.schabi.newpipe.core.data.repository.SubscriptionRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultHistoryRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultPlaylistRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultStreamRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultSubscriptionRepository
+import org.schabi.newpipe.core.data.repository.impl.DefaultFeedRepository
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -27,4 +29,7 @@ abstract class DataModule {
 
     @Binds
     abstract fun bindSubscriptionRepository(impl: DefaultSubscriptionRepository): SubscriptionRepository
+
+    @Binds
+    abstract fun bindFeedRepository(impl: DefaultFeedRepository): FeedRepository
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
@@ -12,6 +12,7 @@ import org.schabi.newpipe.core.data.db.AppDatabase
 import org.schabi.newpipe.core.data.db.HistoryDao
 import org.schabi.newpipe.core.data.db.SubscriptionDao
 import org.schabi.newpipe.core.data.db.PlaylistDao
+import org.schabi.newpipe.core.data.db.FeedDao
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -29,4 +30,7 @@ object DatabaseModule {
 
     @Provides
     fun providePlaylistDao(db: AppDatabase): PlaylistDao = db.playlistDao()
+
+    @Provides
+    fun provideFeedDao(db: AppDatabase): FeedDao = db.feedDao()
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/FeedRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/FeedRepository.kt
@@ -1,0 +1,9 @@
+package org.schabi.newpipe.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.model.Stream
+
+interface FeedRepository {
+    fun getFeed(): Flow<List<Stream>>
+    suspend fun refreshFeed()
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultFeedRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultFeedRepository.kt
@@ -1,0 +1,56 @@
+package org.schabi.newpipe.core.data.repository.impl
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.first
+import org.schabi.newpipe.core.data.db.FeedDao
+import org.schabi.newpipe.core.data.db.FeedItemEntity
+import org.schabi.newpipe.core.data.repository.FeedRepository
+import org.schabi.newpipe.core.data.repository.SubscriptionRepository
+import org.schabi.newpipe.core.model.Stream
+import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.channel.ChannelInfo
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+
+class DefaultFeedRepository @Inject constructor(
+    private val subscriptionRepository: SubscriptionRepository,
+    private val feedDao: FeedDao
+) : FeedRepository {
+    override fun getFeed(): Flow<List<Stream>> =
+        feedDao.getFeed().map { list ->
+            list.map { entity ->
+                Stream(
+                    url = entity.streamUrl,
+                    channelUrl = null,
+                    title = entity.title,
+                    thumbnailUrl = entity.thumbnailUrl,
+                    duration = 0L,
+                    uploader = entity.channelName
+                )
+            }
+        }
+
+    override suspend fun refreshFeed() {
+        val subscriptions = subscriptionRepository.getSubscriptions().first()
+        val allItems = mutableListOf<StreamInfoItem>()
+        for (channel in subscriptions) {
+            val service = NewPipe.getServiceByUrl(channel.url)
+            val info = ChannelInfo.getInfo(service, channel.url)
+            allItems += info.relatedItems
+        }
+        val distinctItems = allItems.distinctBy { it.url }
+            .sortedByDescending { it.uploadDate ?: 0L }
+        val entities = distinctItems.map { item ->
+            FeedItemEntity(
+                streamUrl = item.url,
+                channelName = item.uploaderName,
+                channelAvatarUrl = item.uploaderAvatarUrl,
+                uploadDate = item.uploadDate,
+                title = item.name,
+                thumbnailUrl = item.thumbnailUrl
+            )
+        }
+        feedDao.replaceAll(entities)
+    }
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
@@ -8,6 +8,7 @@ import org.schabi.newpipe.core.data.repository.StreamRepository
 import org.schabi.newpipe.core.data.repository.HistoryRepository
 import org.schabi.newpipe.core.data.repository.SubscriptionRepository
 import org.schabi.newpipe.core.data.repository.PlaylistRepository
+import org.schabi.newpipe.core.data.repository.FeedRepository
 import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.GetSearchResultsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
@@ -22,6 +23,8 @@ import org.schabi.newpipe.core.domain.usecase.AddStreamToPlaylistUseCase
 import org.schabi.newpipe.core.domain.usecase.GetPlaylistItemsUseCase
 import org.schabi.newpipe.core.domain.usecase.RemoveStreamFromPlaylistUseCase
 import org.schabi.newpipe.core.domain.usecase.DeletePlaylistUseCase
+import org.schabi.newpipe.core.domain.usecase.GetFeedUseCase
+import org.schabi.newpipe.core.domain.usecase.RefreshFeedUseCase
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -81,4 +84,12 @@ object DomainModule {
     @Provides
     fun provideDeletePlaylistUseCase(repository: PlaylistRepository): DeletePlaylistUseCase =
         DeletePlaylistUseCase(repository)
+
+    @Provides
+    fun provideGetFeedUseCase(repository: FeedRepository): GetFeedUseCase =
+        GetFeedUseCase(repository)
+
+    @Provides
+    fun provideRefreshFeedUseCase(repository: FeedRepository): RefreshFeedUseCase =
+        RefreshFeedUseCase(repository)
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetFeedUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetFeedUseCase.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.data.repository.FeedRepository
+import org.schabi.newpipe.core.model.Stream
+import javax.inject.Inject
+
+class GetFeedUseCase @Inject constructor(
+    private val repository: FeedRepository
+) {
+    operator fun invoke(): Flow<List<Stream>> = repository.getFeed()
+}

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/RefreshFeedUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/RefreshFeedUseCase.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import org.schabi.newpipe.core.data.repository.FeedRepository
+import javax.inject.Inject
+
+class RefreshFeedUseCase @Inject constructor(
+    private val repository: FeedRepository
+) {
+    suspend operator fun invoke() = repository.refreshFeed()
+}

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
@@ -5,9 +5,11 @@ import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Subscriptions
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PlaylistPlay
+import androidx.compose.material.icons.filled.RssFeed
 import androidx.compose.ui.graphics.vector.ImageVector
 
 enum class MainTab(val route: String, val label: String, val icon: ImageVector) {
+    Feed("feed", "Feed", Icons.Filled.RssFeed),
     Trends("main", "Trends", Icons.Filled.Home),
     History("history", "History", Icons.Filled.History),
     Subscriptions("subscriptions", "Subscriptions", Icons.Filled.Subscriptions),

--- a/feature/feed/build.gradle.kts
+++ b/feature/feed/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.main"
+    namespace = "org.schabi.newpipe.feature.feed"
     defaultConfig { minSdk = 21 }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -22,15 +22,10 @@ android {
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
-    implementation(project(":feature:feed"))
-    implementation(project(":feature:history"))
-    implementation(project(":feature:subscriptions"))
-    implementation(project(":feature:playlists"))
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")

--- a/feature/feed/src/main/java/org/schabi/newpipe/feature/feed/FeedScreen.kt
+++ b/feature/feed/src/main/java/org/schabi/newpipe/feature/feed/FeedScreen.kt
@@ -1,0 +1,57 @@
+package org.schabi.newpipe.feature.feed
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.ui.Alignment
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import org.schabi.newpipe.core.model.Stream
+import org.schabi.newpipe.core.ui.StreamItem
+import org.schabi.newpipe.core.ui.components.MainNavigationBar
+import org.schabi.newpipe.core.ui.components.MainTab
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeedScreen(
+    selectedTab: MainTab,
+    onTabSelected: (MainTab) -> Unit,
+    onStreamSelected: (Stream) -> Unit,
+    viewModel: FeedViewModel = hiltViewModel()
+) {
+    val feed = viewModel.feed.collectAsState().value
+    val refreshing = viewModel.isRefreshing.collectAsState().value
+    val pullState = rememberPullRefreshState(refreshing, { viewModel.refresh() })
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Feed") }) },
+        bottomBar = { MainNavigationBar(selectedTab, onTabSelected) }
+    ) { padding ->
+        Box(Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .pullRefresh(pullState)) {
+            LazyColumn(Modifier.fillMaxSize()) {
+                items(feed) { stream ->
+                    StreamItem(stream, onStreamSelected)
+                }
+            }
+            PullRefreshIndicator(
+                refreshing,
+                pullState,
+                Modifier.align(Alignment.TopCenter)
+            )
+        }
+    }
+}

--- a/feature/feed/src/main/java/org/schabi/newpipe/feature/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/org/schabi/newpipe/feature/feed/FeedViewModel.kt
@@ -1,0 +1,36 @@
+package org.schabi.newpipe.feature.feed
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.schabi.newpipe.core.domain.usecase.GetFeedUseCase
+import org.schabi.newpipe.core.domain.usecase.RefreshFeedUseCase
+import org.schabi.newpipe.core.model.Stream
+
+@HiltViewModel
+class FeedViewModel @Inject constructor(
+    getFeedUseCase: GetFeedUseCase,
+    private val refreshFeedUseCase: RefreshFeedUseCase
+) : ViewModel() {
+    val feed: StateFlow<List<Stream>> =
+        getFeedUseCase()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    fun refresh() {
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            refreshFeedUseCase()
+            _isRefreshing.value = false
+        }
+    }
+}

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
@@ -16,11 +16,19 @@ import org.schabi.newpipe.feature.subscriptions.SubscriptionsScreen
 import org.schabi.newpipe.feature.playlists.PlaylistsScreen
 import org.schabi.newpipe.feature.search.SearchScreen
 import org.schabi.newpipe.feature.settings.SettingsScreen
+import org.schabi.newpipe.feature.feed.FeedScreen
 import org.schabi.newpipe.core.ui.components.MainTab
 
 @Composable
 fun MainNavHost(navController: NavHostController = rememberNavController()) {
-    NavHost(navController, startDestination = MainTab.Trends.route) {
+    NavHost(navController, startDestination = MainTab.Feed.route) {
+        composable(MainTab.Feed.route) {
+            FeedScreen(
+                selectedTab = MainTab.Feed,
+                onTabSelected = { tab -> if (tab != MainTab.Feed) navController.navigate(tab.route) },
+                onStreamSelected = { stream -> navController.navigate("player/${stream.url}") }
+            )
+        }
         composable(MainTab.Trends.route) {
             MainScreen(
                 onStreamSelected = { stream -> navController.navigate("player/${stream.url}") },

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
@@ -5,10 +5,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
@@ -24,6 +33,9 @@ fun DefaultPlayerScreen(url: String, viewModel: PlayerViewModel = hiltViewModel(
     DisposableEffect(Unit) {
         onDispose { player.release() }
     }
+    val playlists = viewModel.playlists.collectAsState().value
+    val showDialog = remember { mutableStateOf(false) }
+
     Column(modifier = Modifier.fillMaxSize()) {
         AndroidView(
             modifier = Modifier.weight(1f),
@@ -34,5 +46,35 @@ fun DefaultPlayerScreen(url: String, viewModel: PlayerViewModel = hiltViewModel(
         Button(onClick = { viewModel.subscribeToCurrentChannel() }) {
             Text("Subscribe")
         }
+        Button(onClick = { showDialog.value = true }) {
+            Text("Add to Playlist")
+        }
+    }
+
+    if (showDialog.value) {
+        AlertDialog(
+            onDismissRequest = { showDialog.value = false },
+            confirmButton = {},
+            title = { Text("Select Playlist") },
+            text = {
+                LazyColumn {
+                    items(playlists) { playlist ->
+                        Text(
+                            text = playlist.name,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    viewModel.addCurrentStreamToPlaylist(playlist.id)
+                                    showDialog.value = false
+                                }
+                                .padding(8.dp)
+                        )
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog.value = false }) { Text("Cancel") }
+            }
+        )
     }
 }

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
@@ -11,27 +11,39 @@ import kotlinx.coroutines.launch
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
 import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.SubscribeToChannelUseCase
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistsUseCase
+import org.schabi.newpipe.core.domain.usecase.AddStreamToPlaylistUseCase
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import org.schabi.newpipe.core.model.Channel
+import org.schabi.newpipe.core.model.LocalPlaylist
 
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
     private val player: ExoPlayer,
     private val getStreamDetails: GetStreamDetailsUseCase,
     private val addStreamToHistory: AddStreamToHistoryUseCase,
-    private val subscribeToChannel: SubscribeToChannelUseCase
+    private val subscribeToChannel: SubscribeToChannelUseCase,
+    getPlaylists: GetPlaylistsUseCase,
+    private val addStreamToPlaylist: AddStreamToPlaylistUseCase
 ) : ViewModel() {
+    val playlists: StateFlow<List<LocalPlaylist>> =
+        getPlaylists().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private var currentChannel: Channel? = null
+    private var currentStream: org.schabi.newpipe.core.model.Stream? = null
 
     fun prepare(url: String) {
         viewModelScope.launch {
             val result = getStreamDetails(url).first()
-            result.onSuccess {
-                player.setMediaItem(MediaItem.fromUri(it.url))
-                addStreamToHistory(it)
+            result.onSuccess { stream ->
+                currentStream = stream
+                player.setMediaItem(MediaItem.fromUri(stream.url))
+                addStreamToHistory(stream)
                 currentChannel = Channel(
-                    url = it.channelUrl ?: it.uploader ?: it.url,
-                    name = it.uploader ?: "",
+                    url = stream.channelUrl ?: stream.uploader ?: stream.url,
+                    name = stream.uploader ?: "",
                     avatarUrl = null
                 )
                 player.prepare()
@@ -53,5 +65,10 @@ class PlayerViewModel @Inject constructor(
     fun subscribeToCurrentChannel() {
         val channel = currentChannel ?: return
         viewModelScope.launch { subscribeToChannel(channel) }
+    }
+
+    fun addCurrentStreamToPlaylist(id: Long) {
+        val stream = currentStream ?: return
+        viewModelScope.launch { addStreamToPlaylist(id, stream) }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(":core:data")
 include(":core:model")
 include(":core:domain")
 include(":feature:player")
+include(":feature:feed")
 include(":feature:main")
 include(":feature:history")
 


### PR DESCRIPTION
## Summary
- implement feed cache entity and DAO
- add feed repository and use cases
- provide feed UI module with pull-to-refresh
- update main navigation to show new feed tab
- allow adding current stream to playlists from player

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684235dc2cd88322abbbc07fa4a28ae3