### PR TITLE
Add channel and playlist detail screens

### DIFF
--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/StreamRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/StreamRepository.kt
@@ -6,4 +6,5 @@ interface StreamRepository {
     suspend fun getStream(url: String): Stream
     suspend fun search(query: String): List<Stream>
     suspend fun getTrending(): List<Stream>
+    suspend fun getStreamsForChannel(channelUrl: String): List<Stream>
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultStreamRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultStreamRepository.kt
@@ -6,6 +6,7 @@ import org.schabi.newpipe.extractor.NewPipe
 import org.schabi.newpipe.extractor.kiosk.KioskInfo
 import org.schabi.newpipe.extractor.search.SearchInfo
 import org.schabi.newpipe.extractor.stream.StreamInfo
+import org.schabi.newpipe.extractor.channel.ChannelInfo
 
 class DefaultStreamRepository : StreamRepository {
     override suspend fun getStream(url: String): Stream {
@@ -45,6 +46,21 @@ class DefaultStreamRepository : StreamRepository {
         val kioskId = kioskList.defaultKioskId
         val url = kioskList.getListLinkHandlerFactoryByType(kioskId).fromId(kioskId).url
         val info = KioskInfo.getInfo(service, url)
+        return info.relatedItems.map { item ->
+            Stream(
+                url = item.url,
+                channelUrl = item.uploaderUrl,
+                title = item.name,
+                thumbnailUrl = item.thumbnailUrl,
+                duration = item.duration,
+                uploader = item.uploaderName
+            )
+        }
+    }
+
+    override suspend fun getStreamsForChannel(channelUrl: String): List<Stream> {
+        val service = NewPipe.getServiceByUrl(channelUrl)
+        val info = ChannelInfo.getInfo(service, channelUrl)
         return info.relatedItems.map { item ->
             Stream(
                 url = item.url,

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
@@ -13,6 +13,7 @@ import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.GetSearchResultsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetTrendingStreamsUseCase
+import org.schabi.newpipe.core.domain.usecase.GetChannelStreamsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetWatchHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.SubscribeToChannelUseCase
 import org.schabi.newpipe.core.domain.usecase.GetSubscriptionsUseCase
@@ -36,6 +37,10 @@ object DomainModule {
     @Provides
     fun provideGetTrendingStreamsUseCase(repository: StreamRepository): GetTrendingStreamsUseCase =
         GetTrendingStreamsUseCase(repository)
+
+    @Provides
+    fun provideGetChannelStreamsUseCase(repository: StreamRepository): GetChannelStreamsUseCase =
+        GetChannelStreamsUseCase(repository)
 
     @Provides
     fun provideGetWatchHistoryUseCase(repository: HistoryRepository): GetWatchHistoryUseCase =

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetChannelStreamsUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetChannelStreamsUseCase.kt
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.schabi.newpipe.core.data.repository.StreamRepository
+import org.schabi.newpipe.core.model.Stream
+import javax.inject.Inject
+
+class GetChannelStreamsUseCase @Inject constructor(
+    private val repository: StreamRepository
+) {
+    suspend operator fun invoke(channelUrl: String): Flow<Result<List<Stream>>> = flow {
+        emit(runCatching { repository.getStreamsForChannel(channelUrl) })
+    }
+}

--- a/feature/channel/build.gradle.kts
+++ b/feature/channel/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.main"
+    namespace = "org.schabi.newpipe.feature.channel"
     defaultConfig { minSdk = 21 }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -22,17 +22,10 @@ android {
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
-    implementation(project(":feature:feed"))
-    implementation(project(":feature:history"))
-    implementation(project(":feature:subscriptions"))
-    implementation(project(":feature:playlists"))
-    implementation(project(":feature:channel"))
-    implementation(project(":feature:playlist_detail"))
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")

--- a/feature/channel/src/main/java/org/schabi/newpipe/feature/channel/ChannelScreen.kt
+++ b/feature/channel/src/main/java/org/schabi/newpipe/feature/channel/ChannelScreen.kt
@@ -1,0 +1,38 @@
+package org.schabi.newpipe.feature.channel
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import org.schabi.newpipe.core.model.Stream
+import org.schabi.newpipe.core.ui.StreamItem
+
+@Composable
+fun ChannelScreen(
+    onStreamSelected: (Stream) -> Unit,
+    viewModel: ChannelViewModel = hiltViewModel()
+) {
+    val streams = viewModel.streams.collectAsState().value
+    val name = viewModel.channelName.collectAsState().value
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text(name) }) }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            items(streams) { stream ->
+                StreamItem(stream, onStreamSelected)
+            }
+        }
+    }
+}

--- a/feature/channel/src/main/java/org/schabi/newpipe/feature/channel/ChannelViewModel.kt
+++ b/feature/channel/src/main/java/org/schabi/newpipe/feature/channel/ChannelViewModel.kt
@@ -1,0 +1,41 @@
+package org.schabi.newpipe.feature.channel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.schabi.newpipe.core.domain.usecase.GetChannelStreamsUseCase
+import org.schabi.newpipe.core.model.Stream
+
+@HiltViewModel
+class ChannelViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getChannelStreams: GetChannelStreamsUseCase
+) : ViewModel() {
+    private val channelUrl: String = checkNotNull(savedStateHandle["channelUrl"])
+
+    private val _channelName = MutableStateFlow("")
+    val channelName: StateFlow<String> = _channelName.asStateFlow()
+
+    private val _streams = MutableStateFlow<List<Stream>>(emptyList())
+    val streams: StateFlow<List<Stream>> = _streams.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            getChannelStreams(channelUrl).collect { result ->
+                result.onSuccess { list ->
+                    _streams.value = list
+                    _channelName.value = list.firstOrNull()?.uploader ?: channelUrl
+                }
+            }
+        }
+    }
+}

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
@@ -14,6 +14,8 @@ import org.schabi.newpipe.NewPlayerActivity
 import org.schabi.newpipe.feature.history.HistoryScreen
 import org.schabi.newpipe.feature.subscriptions.SubscriptionsScreen
 import org.schabi.newpipe.feature.playlists.PlaylistsScreen
+import org.schabi.newpipe.feature.channel.ChannelScreen
+import org.schabi.newpipe.feature.playlist_detail.PlaylistDetailScreen
 import org.schabi.newpipe.feature.search.SearchScreen
 import org.schabi.newpipe.feature.settings.SettingsScreen
 import org.schabi.newpipe.feature.feed.FeedScreen
@@ -50,15 +52,29 @@ fun MainNavHost(navController: NavHostController = rememberNavController()) {
             SubscriptionsScreen(
                 selectedTab = MainTab.Subscriptions,
                 onTabSelected = { tab -> if (tab != MainTab.Subscriptions) navController.navigate(tab.route) },
-                onSearchClicked = { navController.navigate("search") }
+                onSearchClicked = { navController.navigate("search") },
+                onChannelSelected = { channel -> navController.navigate("channel/${channel.url}") }
             )
         }
         composable(MainTab.Playlists.route) {
             PlaylistsScreen(
                 selectedTab = MainTab.Playlists,
                 onTabSelected = { tab -> if (tab != MainTab.Playlists) navController.navigate(tab.route) },
-                onSearchClicked = { navController.navigate("search") }
+                onSearchClicked = { navController.navigate("search") },
+                onPlaylistSelected = { playlist -> navController.navigate("playlist/${playlist.id}") }
             )
+        }
+        composable(
+            route = "channel/{channelUrl}",
+            arguments = listOf(navArgument("channelUrl") { type = NavType.StringType })
+        ) {
+            ChannelScreen(onStreamSelected = { stream -> navController.navigate("player/${stream.url}") })
+        }
+        composable(
+            route = "playlist/{playlistId}",
+            arguments = listOf(navArgument("playlistId") { type = NavType.LongType })
+        ) {
+            PlaylistDetailScreen(onStreamSelected = { stream -> navController.navigate("player/${stream.url}") })
         }
         composable("search") {
             SearchScreen(onStreamSelected = { stream -> navController.navigate("player/${stream.url}") })

--- a/feature/playlist_detail/build.gradle.kts
+++ b/feature/playlist_detail/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.main"
+    namespace = "org.schabi.newpipe.feature.playlist_detail"
     defaultConfig { minSdk = 21 }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -22,17 +22,10 @@ android {
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
-    implementation(project(":feature:feed"))
-    implementation(project(":feature:history"))
-    implementation(project(":feature:subscriptions"))
-    implementation(project(":feature:playlists"))
-    implementation(project(":feature:channel"))
-    implementation(project(":feature:playlist_detail"))
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")

--- a/feature/playlist_detail/src/main/java/org/schabi/newpipe/feature/playlist_detail/PlaylistDetailScreen.kt
+++ b/feature/playlist_detail/src/main/java/org/schabi/newpipe/feature/playlist_detail/PlaylistDetailScreen.kt
@@ -1,0 +1,38 @@
+package org.schabi.newpipe.feature.playlist_detail
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import org.schabi.newpipe.core.model.Stream
+import org.schabi.newpipe.core.ui.StreamItem
+
+@Composable
+fun PlaylistDetailScreen(
+    onStreamSelected: (Stream) -> Unit,
+    viewModel: PlaylistDetailViewModel = hiltViewModel()
+) {
+    val streams = viewModel.streams.collectAsState().value
+    val name = viewModel.playlistName.collectAsState().value
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text(name) }) }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            items(streams) { stream ->
+                StreamItem(stream, onStreamSelected)
+            }
+        }
+    }
+}

--- a/feature/playlist_detail/src/main/java/org/schabi/newpipe/feature/playlist_detail/PlaylistDetailViewModel.kt
+++ b/feature/playlist_detail/src/main/java/org/schabi/newpipe/feature/playlist_detail/PlaylistDetailViewModel.kt
@@ -1,0 +1,32 @@
+package org.schabi.newpipe.feature.playlist_detail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.map
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistItemsUseCase
+import org.schabi.newpipe.core.domain.usecase.GetPlaylistsUseCase
+import org.schabi.newpipe.core.model.Stream
+
+@HiltViewModel
+class PlaylistDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    getPlaylistItemsUseCase: GetPlaylistItemsUseCase,
+    getPlaylistsUseCase: GetPlaylistsUseCase
+) : ViewModel() {
+    private val playlistId: Long = checkNotNull(savedStateHandle["playlistId"]).toString().toLong()
+
+    val streams: StateFlow<List<Stream>> =
+        getPlaylistItemsUseCase(playlistId)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val playlistName: StateFlow<String> =
+        getPlaylistsUseCase()
+            .map { list -> list.firstOrNull { it.id == playlistId }?.name ?: "" }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "")
+}

--- a/feature/subscriptions/src/main/java/org/schabi/newpipe/feature/subscriptions/SubscriptionsScreen.kt
+++ b/feature/subscriptions/src/main/java/org/schabi/newpipe/feature/subscriptions/SubscriptionsScreen.kt
@@ -20,6 +20,7 @@ import coil.compose.AsyncImage
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.clickable
 import org.schabi.newpipe.core.model.Channel
 import org.schabi.newpipe.core.ui.components.MainNavigationBar
 import org.schabi.newpipe.core.ui.components.MainTab
@@ -29,6 +30,7 @@ fun SubscriptionsScreen(
     selectedTab: MainTab,
     onTabSelected: (MainTab) -> Unit,
     onSearchClicked: () -> Unit,
+    onChannelSelected: (Channel) -> Unit,
     viewModel: SubscriptionsViewModel = hiltViewModel()
 ) {
     val subs = viewModel.subscriptions.collectAsState().value
@@ -47,15 +49,15 @@ fun SubscriptionsScreen(
     ) { padding ->
         LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
             items(subs) { channel ->
-                ChannelRow(channel)
+                ChannelRow(channel) { onChannelSelected(channel) }
             }
         }
     }
 }
 
 @Composable
-private fun ChannelRow(channel: Channel) {
-    Row(modifier = Modifier.padding(8.dp)) {
+private fun ChannelRow(channel: Channel, onClick: () -> Unit) {
+    Row(modifier = Modifier.padding(8.dp).clickable(onClick = onClick)) {
         AsyncImage(model = channel.avatarUrl, contentDescription = null)
         Spacer(Modifier.width(8.dp))
         Text(text = channel.name)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,8 @@ include(":feature:search")
 include(":feature:subscriptions")
 include(":feature:playlists")
 include(":feature:settings")
+include(":feature:channel")
+include(":feature:playlist_detail")
 // Use a local copy of NewPipe Extractor by uncommenting the lines below.
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().


### PR DESCRIPTION
## Summary
- fetch channel streams via repository
- wire up new use case provider
- show channel detail screen
- show playlist detail screen
- navigate to new detail screens from subscriptions and playlists
- include new modules in build and navigation

## Testing
- `./gradlew assembleDebug` *(fails: SDK not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68423952b5788322b09a6876601eb191