### PR TITLE
Implement downloads feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,4 +89,5 @@ dependencies {
     implementation(project(":feature:search"))
     implementation(project(":feature:subscriptions"))
     implementation(project(":feature:settings"))
+    implementation(project(":feature:downloads"))
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -11,13 +11,15 @@ import androidx.room.migration.AutoMigrationSpec
         SubscriptionEntity::class,
         PlaylistEntity::class,
         PlaylistItemEntity::class,
-        FeedItemEntity::class
+        FeedItemEntity::class,
+        DownloadEntity::class
     ],
-    version = 4,
+    version = 5,
     autoMigrations = [
         AutoMigration(from = 1, to = 2, spec = AppDatabase.Migration1To2::class),
         AutoMigration(from = 2, to = 3, spec = AppDatabase.Migration2To3::class),
-        AutoMigration(from = 3, to = 4, spec = AppDatabase.Migration3To4::class)
+        AutoMigration(from = 3, to = 4, spec = AppDatabase.Migration3To4::class),
+        AutoMigration(from = 4, to = 5, spec = AppDatabase.Migration4To5::class)
     ]
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -25,8 +27,10 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun subscriptionDao(): SubscriptionDao
     abstract fun playlistDao(): PlaylistDao
     abstract fun feedDao(): FeedDao
+    abstract fun downloadDao(): DownloadDao
 
     class Migration1To2 : AutoMigrationSpec
     class Migration2To3 : AutoMigrationSpec
     class Migration3To4 : AutoMigrationSpec
+    class Migration4To5 : AutoMigrationSpec
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/DownloadDao.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/DownloadDao.kt
@@ -1,0 +1,20 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Delete
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface DownloadDao {
+    @Query("SELECT * FROM downloads")
+    fun getDownloads(): Flow<List<DownloadEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: DownloadEntity)
+
+    @Query("DELETE FROM downloads WHERE streamUrl = :streamUrl")
+    suspend fun delete(streamUrl: String)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/DownloadEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/DownloadEntity.kt
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.core.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "downloads")
+data class DownloadEntity(
+    @PrimaryKey val streamUrl: String,
+    val title: String,
+    val thumbnailUrl: String?,
+    val localFilePath: String,
+    val mediaType: String,
+    val status: String,
+    val progress: Int
+)

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DataModule.kt
@@ -9,11 +9,13 @@ import org.schabi.newpipe.core.data.repository.PlaylistRepository
 import org.schabi.newpipe.core.data.repository.FeedRepository
 import org.schabi.newpipe.core.data.repository.StreamRepository
 import org.schabi.newpipe.core.data.repository.SubscriptionRepository
+import org.schabi.newpipe.core.data.repository.DownloadRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultHistoryRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultPlaylistRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultStreamRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultSubscriptionRepository
 import org.schabi.newpipe.core.data.repository.impl.DefaultFeedRepository
+import org.schabi.newpipe.core.data.repository.impl.DefaultDownloadRepository
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -32,4 +34,7 @@ abstract class DataModule {
 
     @Binds
     abstract fun bindFeedRepository(impl: DefaultFeedRepository): FeedRepository
+
+    @Binds
+    abstract fun bindDownloadRepository(impl: DefaultDownloadRepository): DownloadRepository
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/di/DatabaseModule.kt
@@ -13,6 +13,7 @@ import org.schabi.newpipe.core.data.db.HistoryDao
 import org.schabi.newpipe.core.data.db.SubscriptionDao
 import org.schabi.newpipe.core.data.db.PlaylistDao
 import org.schabi.newpipe.core.data.db.FeedDao
+import org.schabi.newpipe.core.data.db.DownloadDao
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -33,4 +34,7 @@ object DatabaseModule {
 
     @Provides
     fun provideFeedDao(db: AppDatabase): FeedDao = db.feedDao()
+
+    @Provides
+    fun provideDownloadDao(db: AppDatabase): DownloadDao = db.downloadDao()
 }

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/DownloadRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/DownloadRepository.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.core.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.model.Download
+
+interface DownloadRepository {
+    fun getDownloads(): Flow<List<Download>>
+    suspend fun upsert(download: Download)
+    suspend fun delete(streamUrl: String)
+}

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultDownloadRepository.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/repository/impl/DefaultDownloadRepository.kt
@@ -1,0 +1,46 @@
+package org.schabi.newpipe.core.data.repository.impl
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.schabi.newpipe.core.data.db.DownloadDao
+import org.schabi.newpipe.core.data.db.DownloadEntity
+import org.schabi.newpipe.core.data.repository.DownloadRepository
+import org.schabi.newpipe.core.model.Download
+
+class DefaultDownloadRepository @Inject constructor(
+    private val dao: DownloadDao
+) : DownloadRepository {
+    override fun getDownloads(): Flow<List<Download>> =
+        dao.getDownloads().map { list ->
+            list.map { it.toModel() }
+        }
+
+    override suspend fun upsert(download: Download) {
+        dao.upsert(download.toEntity())
+    }
+
+    override suspend fun delete(streamUrl: String) {
+        dao.delete(streamUrl)
+    }
+}
+
+private fun DownloadEntity.toModel() = Download(
+    streamUrl = streamUrl,
+    title = title,
+    thumbnailUrl = thumbnailUrl,
+    localFilePath = localFilePath,
+    mediaType = mediaType,
+    status = status,
+    progress = progress
+)
+
+private fun Download.toEntity() = DownloadEntity(
+    streamUrl = streamUrl,
+    title = title,
+    thumbnailUrl = thumbnailUrl,
+    localFilePath = localFilePath,
+    mediaType = mediaType,
+    status = status,
+    progress = progress
+)

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/di/DomainModule.kt
@@ -9,6 +9,7 @@ import org.schabi.newpipe.core.data.repository.HistoryRepository
 import org.schabi.newpipe.core.data.repository.SubscriptionRepository
 import org.schabi.newpipe.core.data.repository.PlaylistRepository
 import org.schabi.newpipe.core.data.repository.FeedRepository
+import org.schabi.newpipe.core.data.repository.DownloadRepository
 import org.schabi.newpipe.core.domain.usecase.AddStreamToHistoryUseCase
 import org.schabi.newpipe.core.domain.usecase.GetSearchResultsUseCase
 import org.schabi.newpipe.core.domain.usecase.GetStreamDetailsUseCase
@@ -26,6 +27,7 @@ import org.schabi.newpipe.core.domain.usecase.RemoveStreamFromPlaylistUseCase
 import org.schabi.newpipe.core.domain.usecase.DeletePlaylistUseCase
 import org.schabi.newpipe.core.domain.usecase.GetFeedUseCase
 import org.schabi.newpipe.core.domain.usecase.RefreshFeedUseCase
+import org.schabi.newpipe.core.domain.usecase.GetDownloadsUseCase
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -97,4 +99,8 @@ object DomainModule {
     @Provides
     fun provideRefreshFeedUseCase(repository: FeedRepository): RefreshFeedUseCase =
         RefreshFeedUseCase(repository)
+
+    @Provides
+    fun provideGetDownloadsUseCase(repository: DownloadRepository): GetDownloadsUseCase =
+        GetDownloadsUseCase(repository)
 }

--- a/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetDownloadsUseCase.kt
+++ b/core/domain/src/main/java/org/schabi/newpipe/core/domain/usecase/GetDownloadsUseCase.kt
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.core.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import org.schabi.newpipe.core.data.repository.DownloadRepository
+import org.schabi.newpipe.core.model.Download
+import javax.inject.Inject
+
+class GetDownloadsUseCase @Inject constructor(
+    private val repository: DownloadRepository
+) {
+    operator fun invoke(): Flow<List<Download>> = repository.getDownloads()
+}

--- a/core/model/src/main/java/org/schabi/newpipe/core/model/Download.kt
+++ b/core/model/src/main/java/org/schabi/newpipe/core/model/Download.kt
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.core.model
+
+data class Download(
+    val streamUrl: String,
+    val title: String,
+    val thumbnailUrl: String?,
+    val localFilePath: String,
+    val mediaType: String,
+    val status: String,
+    val progress: Int
+)

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/components/MainTab.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Subscriptions
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PlaylistPlay
 import androidx.compose.material.icons.filled.RssFeed
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.ui.graphics.vector.ImageVector
 
 enum class MainTab(val route: String, val label: String, val icon: ImageVector) {
@@ -13,5 +14,6 @@ enum class MainTab(val route: String, val label: String, val icon: ImageVector) 
     Trends("main", "Trends", Icons.Filled.Home),
     History("history", "History", Icons.Filled.History),
     Subscriptions("subscriptions", "Subscriptions", Icons.Filled.Subscriptions),
-    Playlists("playlists", "Playlists", Icons.Filled.PlaylistPlay)
+    Playlists("playlists", "Playlists", Icons.Filled.PlaylistPlay),
+    Downloads("downloads", "Downloads", Icons.Filled.Download)
 }

--- a/feature/downloads/build.gradle.kts
+++ b/feature/downloads/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk = 36
-    namespace = "org.schabi.newpipe.feature.player"
+    namespace = "org.schabi.newpipe.feature.downloads"
     defaultConfig { minSdk = 21 }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -14,20 +14,18 @@ android {
     }
     kotlinOptions { jvmTarget = "17" }
     buildFeatures { compose = true }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String
-    }
+    composeOptions { kotlinCompilerExtensionVersion = rootProject.extra["compose_compiler_version"] as String }
 }
 
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
+    implementation(project(":core:data"))
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
-    implementation("androidx.media3:media3-exoplayer:1.3.1")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
     implementation("androidx.work:work-runtime-ktx:2.9.0")

--- a/feature/downloads/src/main/java/org/schabi/newpipe/feature/downloads/DownloadWorker.kt
+++ b/feature/downloads/src/main/java/org/schabi/newpipe/feature/downloads/DownloadWorker.kt
@@ -1,0 +1,122 @@
+package org.schabi.newpipe.feature.downloads
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.io.File
+import java.net.URL
+import org.schabi.newpipe.core.data.repository.DownloadRepository
+import org.schabi.newpipe.core.model.Download
+import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.stream.StreamInfo
+
+@HiltWorker
+class DownloadWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val repository: DownloadRepository
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val url = inputData.getString(KEY_STREAM_URL) ?: return Result.failure()
+        val type = inputData.getString(KEY_MEDIA_TYPE) ?: "video"
+        return try {
+            val service = NewPipe.getServiceByUrl(url)
+            val info = StreamInfo.getInfo(service, url)
+            val stream = if (type == "audio") info.audioStreams.first() else info.videoStreams.first()
+            val file = File(applicationContext.filesDir, System.currentTimeMillis().toString())
+            val connection = URL(stream.url).openConnection()
+            val total = connection.contentLength
+            val input = connection.getInputStream()
+            file.outputStream().use { out ->
+                var downloaded = 0
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                var read: Int
+                while (input.read(buffer).also { read = it } != -1) {
+                    out.write(buffer, 0, read)
+                    downloaded += read
+                    val progress = if (total > 0) (downloaded * 100 / total) else 0
+                    repository.upsert(
+                        Download(
+                            streamUrl = url,
+                            title = info.name,
+                            thumbnailUrl = info.thumbnailUrl,
+                            localFilePath = file.absolutePath,
+                            mediaType = type,
+                            status = STATUS_DOWNLOADING,
+                            progress = progress
+                        )
+                    )
+                    setForeground(createForegroundInfo(progress, info.name))
+                }
+            }
+            repository.upsert(
+                Download(
+                    streamUrl = url,
+                    title = info.name,
+                    thumbnailUrl = info.thumbnailUrl,
+                    localFilePath = file.absolutePath,
+                    mediaType = type,
+                    status = STATUS_COMPLETED,
+                    progress = 100
+                )
+            )
+            Result.success()
+        } catch (e: Exception) {
+            repository.upsert(
+                Download(
+                    streamUrl = url,
+                    title = "",
+                    thumbnailUrl = null,
+                    localFilePath = "",
+                    mediaType = type,
+                    status = STATUS_FAILED,
+                    progress = 0
+                )
+            )
+            Result.failure()
+        }
+    }
+
+    private fun createForegroundInfo(progress: Int, title: String): ForegroundInfo {
+        createChannel()
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setContentTitle(title)
+            .setProgress(100, progress, false)
+            .build()
+        return ForegroundInfo(NOTIFICATION_ID, notification)
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(CHANNEL_ID, "Downloads", NotificationManager.IMPORTANCE_LOW)
+            NotificationManagerCompat.from(applicationContext).createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "download"
+        private const val NOTIFICATION_ID = 1001
+        const val STATUS_DOWNLOADING = "downloading"
+        const val STATUS_COMPLETED = "completed"
+        const val STATUS_FAILED = "failed"
+        const val KEY_STREAM_URL = "streamUrl"
+        const val KEY_MEDIA_TYPE = "mediaType"
+
+        fun buildData(url: String, mediaType: String) = workDataOf(
+            KEY_STREAM_URL to url,
+            KEY_MEDIA_TYPE to mediaType
+        )
+    }
+}

--- a/feature/downloads/src/main/java/org/schabi/newpipe/feature/downloads/DownloadsScreen.kt
+++ b/feature/downloads/src/main/java/org/schabi/newpipe/feature/downloads/DownloadsScreen.kt
@@ -1,0 +1,43 @@
+package org.schabi.newpipe.feature.downloads
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import org.schabi.newpipe.core.ui.components.MainNavigationBar
+import org.schabi.newpipe.core.ui.components.MainTab
+
+@Composable
+fun DownloadsScreen(
+    selectedTab: MainTab,
+    onTabSelected: (MainTab) -> Unit,
+    viewModel: DownloadsViewModel = hiltViewModel()
+) {
+    val downloads = viewModel.downloads.collectAsState().value
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Downloads") }) },
+        bottomBar = { MainNavigationBar(selectedTab, onTabSelected) }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            items(downloads) { item ->
+                Column(modifier = Modifier.padding(8.dp)) {
+                    Text(text = item.title)
+                    AsyncImage(model = item.thumbnailUrl, contentDescription = null)
+                    LinearProgressIndicator(progress = item.progress / 100f, modifier = Modifier.fillMaxSize())
+                    Text(text = item.status)
+                }
+            }
+        }
+    }
+}

--- a/feature/downloads/src/main/java/org/schabi/newpipe/feature/downloads/DownloadsViewModel.kt
+++ b/feature/downloads/src/main/java/org/schabi/newpipe/feature/downloads/DownloadsViewModel.kt
@@ -1,0 +1,19 @@
+package org.schabi.newpipe.feature.downloads
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import org.schabi.newpipe.core.domain.usecase.GetDownloadsUseCase
+import org.schabi.newpipe.core.model.Download
+
+@HiltViewModel
+class DownloadsViewModel @Inject constructor(
+    getDownloads: GetDownloadsUseCase
+) : ViewModel() {
+    val downloads: StateFlow<List<Download>> =
+        getDownloads().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+}

--- a/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
+++ b/feature/main/src/main/java/org/schabi/newpipe/feature/main/MainNavigation.kt
@@ -19,6 +19,7 @@ import org.schabi.newpipe.feature.playlist_detail.PlaylistDetailScreen
 import org.schabi.newpipe.feature.search.SearchScreen
 import org.schabi.newpipe.feature.settings.SettingsScreen
 import org.schabi.newpipe.feature.feed.FeedScreen
+import org.schabi.newpipe.feature.downloads.DownloadsScreen
 import org.schabi.newpipe.core.ui.components.MainTab
 
 @Composable
@@ -62,6 +63,12 @@ fun MainNavHost(navController: NavHostController = rememberNavController()) {
                 onTabSelected = { tab -> if (tab != MainTab.Playlists) navController.navigate(tab.route) },
                 onSearchClicked = { navController.navigate("search") },
                 onPlaylistSelected = { playlist -> navController.navigate("playlist/${playlist.id}") }
+            )
+        }
+        composable(MainTab.Downloads.route) {
+            DownloadsScreen(
+                selectedTab = MainTab.Downloads,
+                onTabSelected = { tab -> if (tab != MainTab.Downloads) navController.navigate(tab.route) }
             )
         }
         composable(

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerScreen.kt
@@ -35,6 +35,7 @@ fun DefaultPlayerScreen(url: String, viewModel: PlayerViewModel = hiltViewModel(
     }
     val playlists = viewModel.playlists.collectAsState().value
     val showDialog = remember { mutableStateOf(false) }
+    val showDownloadDialog = remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         AndroidView(
@@ -48,6 +49,9 @@ fun DefaultPlayerScreen(url: String, viewModel: PlayerViewModel = hiltViewModel(
         }
         Button(onClick = { showDialog.value = true }) {
             Text("Add to Playlist")
+        }
+        Button(onClick = { showDownloadDialog.value = true }) {
+            Text("Download")
         }
     }
 
@@ -74,6 +78,29 @@ fun DefaultPlayerScreen(url: String, viewModel: PlayerViewModel = hiltViewModel(
             },
             dismissButton = {
                 TextButton(onClick = { showDialog.value = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    if (showDownloadDialog.value) {
+        AlertDialog(
+            onDismissRequest = { showDownloadDialog.value = false },
+            confirmButton = {},
+            title = { Text("Download") },
+            text = {
+                Column {
+                    Button(onClick = {
+                        viewModel.downloadCurrentStream("video")
+                        showDownloadDialog.value = false
+                    }) { Text("Video") }
+                    Button(onClick = {
+                        viewModel.downloadCurrentStream("audio")
+                        showDownloadDialog.value = false
+                    }) { Text("Audio") }
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDownloadDialog.value = false }) { Text("Cancel") }
             }
         )
     }

--- a/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/org/schabi/newpipe/feature/player/PlayerViewModel.kt
@@ -1,7 +1,11 @@
 package org.schabi.newpipe.feature.player
 
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,6 +22,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import org.schabi.newpipe.core.model.Channel
 import org.schabi.newpipe.core.model.LocalPlaylist
+import org.schabi.newpipe.feature.downloads.DownloadWorker
 
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
@@ -26,7 +31,8 @@ class PlayerViewModel @Inject constructor(
     private val addStreamToHistory: AddStreamToHistoryUseCase,
     private val subscribeToChannel: SubscribeToChannelUseCase,
     getPlaylists: GetPlaylistsUseCase,
-    private val addStreamToPlaylist: AddStreamToPlaylistUseCase
+    private val addStreamToPlaylist: AddStreamToPlaylistUseCase,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
     val playlists: StateFlow<List<LocalPlaylist>> =
         getPlaylists().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -70,5 +76,13 @@ class PlayerViewModel @Inject constructor(
     fun addCurrentStreamToPlaylist(id: Long) {
         val stream = currentStream ?: return
         viewModelScope.launch { addStreamToPlaylist(id, stream) }
+    }
+
+    fun downloadCurrentStream(type: String) {
+        val stream = currentStream ?: return
+        val request = OneTimeWorkRequestBuilder<DownloadWorker>()
+            .setInputData(DownloadWorker.buildData(stream.url, type))
+            .build()
+        WorkManager.getInstance(context).enqueue(request)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ include(":feature:playlists")
 include(":feature:settings")
 include(":feature:channel")
 include(":feature:playlist_detail")
+include(":feature:downloads")
 // Use a local copy of NewPipe Extractor by uncommenting the lines below.
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().


### PR DESCRIPTION
## Summary
- introduce DownloadEntity and DAO
- store download metadata via DownloadRepository
- expose GetDownloadsUseCase in the domain layer
- create new downloads module with DownloadWorker, screen and viewmodel
- add download button to player and integrate new tab

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c3c5072083228bfd83732984175d