### PR TITLE
Fix Compose BOM version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
     extra["kotlin_version"] = "2.1.21"
     extra["hilt_version"] = "2.51"
     extra["compose_compiler_version"] = "1.5.10"
-    extra["compose_bom_version"] = "2025.06.01"
+    extra["compose_bom_version"] = "2025.05.00"
 }
 
 subprojects {


### PR DESCRIPTION
## Summary
- downgrade compose BOM to stable 2025.05.00

## Testing
- `./gradlew --version`
- `./gradlew test` *(fails: could not complete due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842e3ef4f948322bf1907f9f10a306f