### PR TITLE
Fix compileSdk mismatch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe"
 
     defaultConfig {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.core.data"
     defaultConfig { minSdk = 21 }
     compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.core.domain"
     defaultConfig { minSdk = 21 }
     compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.core.model"
     defaultConfig { minSdk = 21 }
     compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.core.ui"
 
     defaultConfig {

--- a/feature/channel/build.gradle.kts
+++ b/feature/channel/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.channel"
     defaultConfig { minSdk = 21 }
     compileOptions {

--- a/feature/downloads/build.gradle.kts
+++ b/feature/downloads/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.downloads"
     defaultConfig { minSdk = 21 }
     compileOptions {

--- a/feature/feed/build.gradle.kts
+++ b/feature/feed/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.feed"
     defaultConfig { minSdk = 21 }
     compileOptions {

--- a/feature/history/build.gradle.kts
+++ b/feature/history/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.history"
     defaultConfig { minSdk = 21 }
     compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.main"
     defaultConfig { minSdk = 21 }
     compileOptions {

--- a/feature/player/build.gradle.kts
+++ b/feature/player/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.player"
     defaultConfig { minSdk = 21 }
     compileOptions {

--- a/feature/playlist_detail/build.gradle.kts
+++ b/feature/playlist_detail/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.playlist_detail"
     defaultConfig { minSdk = 21 }
     compileOptions {

--- a/feature/playlists/build.gradle.kts
+++ b/feature/playlists/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.playlists"
     defaultConfig { minSdk = 21 }
     compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.search"
     defaultConfig { minSdk = 21 }
     compileOptions {

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.settings"
     defaultConfig { minSdk = 21 }
     compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }

--- a/feature/subscriptions/build.gradle.kts
+++ b/feature/subscriptions/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 34
     namespace = "org.schabi.newpipe.feature.subscriptions"
     defaultConfig { minSdk = 21 }
     compileOptions {


### PR DESCRIPTION
## Summary
- lower compileSdk from 36 to 34 across all modules

## Testing
- `./gradlew help`
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e6e5fbf88322b465a16b79cb8fde