### PR TITLE
Fix wrong Gradle wrapper checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=845952a9d6afa783db70bb3b0effaae45ae5542ca2bb7929619e8af49cb634cf
+distributionSha256Sum=03ec176d388f2aa99defcadc3ac6adf8dd2bce5145a129659537c0874dea5ad1
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- correct the `distributionSha256Sum` for the Gradle wrapper

## Testing
- `./gradlew test --no-daemon` *(fails: process aborted before completion)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef5916d48322a7c9eeefbfb17f7c