### PR TITLE
Fix coroutine dependency version

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation(project(":core:model"))
     implementation("androidx.room:room-runtime:2.7.1")
     kapt("androidx.room:room-compiler:2.7.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.6")
     implementation("androidx.datastore:datastore-preferences:1.1.0")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:data"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
 }


### PR DESCRIPTION
## Summary
- correct `kotlinx-coroutines-core` version in data and domain modules

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f3b151b48322974b7520238852de