### PR TITLE
Fix Compose BOM version for build compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
     extra["kotlin_version"] = "2.1.21"
     extra["hilt_version"] = "2.48"
     extra["compose_compiler_version"] = "1.5.10"
-    extra["compose_bom_version"] = "2025.05.00"
+    extra["compose_bom_version"] = "2024.02.02"
 }
 
 subprojects {


### PR DESCRIPTION
## Summary
- downgrade Compose BOM to 2024.02.02 in `build.gradle.kts`

## Testing
- `git log -1 --stat`
- `git push` *(fails: no remote configured)*

------
https://chatgpt.com/codex/tasks/task_e_6842f736d6a48322b126dedb2c4d89af