### PR TITLE
Fix dependency resolution conflict

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     implementation("com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.6")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${rootProject.extra["kotlin_version"]}")
 
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.11.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,10 @@ allprojects {
     extra["kotlin_version"] = "2.1.21"
     extra["hilt_version"] = "2.48"
     extra["compose_compiler_version"] = "1.5.10"
-    extra["compose_bom_version"] = "2024.02.02"
+    extra["compose_bom_version"] = "2025.05.00"
+    configurations.all {
+        resolutionStrategy.force("androidx.core:core-ktx:1.12.0")
+    }
 }
 
 subprojects {


### PR DESCRIPTION
## Summary
- revert compose BOM downgrade to `2025.05.00`
- force `androidx.core:core-ktx` 1.12.0 for all modules
- downgrade `core-ktx` dependency in `app` module

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f8c01630832285a94ab2331c296a