### PR TITLE
Update Gradle build to maintain compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     implementation("com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.6")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${rootProject.extra["kotlin_version"]}")
 
-    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.11.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,10 +28,7 @@ allprojects {
     extra["kotlin_version"] = "2.1.21"
     extra["hilt_version"] = "2.48"
     extra["compose_compiler_version"] = "1.5.10"
-    extra["compose_bom_version"] = "2025.05.00"
-    configurations.all {
-        resolutionStrategy.force("androidx.core:core-ktx:1.12.0")
-    }
+    extra["compose_bom_version"] = "2024.02.02"
 }
 
 subprojects {


### PR DESCRIPTION
## Summary
- downgrade Compose BOM to 2024.02.02 in root Gradle
- revert accidental downgrade of core-ktx
- clean up outdated forced resolution strategy

## Testing
- `./gradlew --version`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb260fac83228b5dc6409083ae68