### PR TITLE
Downgrade core-ktx to 1.12.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     implementation("com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.6")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${rootProject.extra["kotlin_version"]}")
 
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.11.0")
 


### PR DESCRIPTION
## Summary
- downgrade `androidx.core:core-ktx` to `1.12.0` for compatibility

## Testing
- `./gradlew --no-daemon help`
- `./gradlew --no-daemon assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fdf9b3b083229baad57665307870