### PR TITLE
Downgrade Room to 2.6.1

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -14,8 +14,8 @@ android {
 
 dependencies {
     implementation(project(":core:model"))
-    implementation("androidx.room:room-runtime:2.7.1")
-    kapt("androidx.room:room-compiler:2.7.1")
+    implementation("androidx.room:room-runtime:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.6")
     implementation("androidx.datastore:datastore-preferences:1.1.0")


### PR DESCRIPTION
## Summary
- fix dependencies to use Room 2.6.1 instead of 2.7.1

## Testing
- `git log -1`


------
https://chatgpt.com/codex/tasks/task_e_68430092f0388322adcce3835c0a8a8f