### PR TITLE
Update detekt version

### DIFF
--- a/DEPENDENCY_UPDATES_2025-06-06.md
+++ b/DEPENDENCY_UPDATES_2025-06-06.md
@@ -23,7 +23,7 @@
 - Coil: 2.6.0 → 2.8.0
 
 ## Quality Tools
-- Detekt: 1.23.6 → 1.24.0
+- Detekt: 1.23.6 → 1.23.8
 - SonarQube: 4.0.0.2929 → 4.2.0
 
 ## Breaking Changes

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "1.24.0" apply false // [Update 2025-06-06: von 1.23.6]
+    id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false // [Update 2025-06-06: von 1.24.0]
 }
 
 buildscript {


### PR DESCRIPTION
## Summary
- downgrade detekt plugin from 1.24.0 to 1.23.8
- sync dependency updates documentation

## Testing
- `./gradlew detekt --dry-run` *(fails: Plugin [id: 'org.sonarqube'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431f12b08883229809be62a5d7fd2a