### PR TITLE
Add missing settings header layout

### DIFF
--- a/app/src/main/res/layout/settings_category_header_layout.xml
+++ b/app/src/main/res/layout/settings_category_header_layout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Header-Layout für PreferenceCategory-Titel                 -->
+<!--  Angelehnt an Upstream NewPipe (dev branch, 2025-06-06).    -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceHeadlineSmall"
+        android:fontFamily="sans-serif-medium"
+        android:textColor="?attr/colorOnSurface" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add `settings_category_header_layout.xml` to fix missing resource error

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843407465d08322b29f07bcca615a8c