### PR TITLE
Add model dependency and fix ForeignKey usage

### DIFF
--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistItemEntity.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/PlaylistItemEntity.kt
@@ -4,7 +4,6 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import androidx.room.ForeignKey.CASCADE
 
 @Entity(
     tableName = "playlist_items",
@@ -13,7 +12,7 @@ import androidx.room.ForeignKey.CASCADE
             entity = PlaylistEntity::class,
             parentColumns = ["id"],
             childColumns = ["playlistId"],
-            onDelete = CASCADE
+            onDelete = ForeignKey.CASCADE
         )
     ],
     indices = [Index("playlistId")]

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -25,6 +25,8 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:model"))
+    implementation("androidx.compose.material:material-icons-extended")
     implementation(platform("androidx.compose:compose-bom:${rootProject.extra["compose_bom_version"]}"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")


### PR DESCRIPTION
## Summary
- add `core:model` and Compose icons to `core:ui`
- reference `ForeignKey.CASCADE` correctly in `PlaylistItemEntity`

## Testing
- `./gradlew help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68434792d1f88322a9863ec96b1a7278