### PR TITLE
Fix compose API call and configure Room schema export

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -10,6 +10,14 @@ android {
     defaultConfig { minSdk = 21 }
     compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }
     kotlinOptions { jvmTarget = "17" }
+
+    kapt {
+        arguments {
+            arg("room.schemaLocation", "$projectDir/schemas")
+            arg("room.incremental", "true")
+            arg("room.expandProjection", "true")
+        }
+    }
 }
 
 dependencies {

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -20,7 +20,8 @@ import androidx.room.migration.AutoMigrationSpec
         AutoMigration(from = 2, to = 3, spec = AppDatabase.Migration2To3::class),
         AutoMigration(from = 3, to = 4, spec = AppDatabase.Migration3To4::class),
         AutoMigration(from = 4, to = 5, spec = AppDatabase.Migration4To5::class)
-    ]
+    ],
+    exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/theme/NewPipeTheme.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/theme/NewPipeTheme.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.platform.LocalContext
 fun NewPipeTheme(content: @Composable () -> Unit) {
     val context = LocalContext.current
     val colorScheme = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        if (MaterialTheme.colorScheme.isLight) {
+        if (MaterialTheme.colorScheme.isLight()) {
             dynamicLightColorScheme(context)
         } else {
             dynamicDarkColorScheme(context)


### PR DESCRIPTION
## Summary
- update `NewPipeTheme` to use `isLight()`
- configure Room's schemaLocation in `core:data` build config
- enable schema export in `AppDatabase`

## Testing
- `./gradlew --version`
- `./gradlew help` *(failed: process hung or incomplete output)*

------
https://chatgpt.com/codex/tasks/task_e_68434d7d41c8832280710e873c1e3ba2