### PR TITLE
Fix Gradle wrapper checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e606c1da22d3d6e7954ef51e4e45472ed97350e6ba60c36290f9c362dc4dc22f
+distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
 distributionUrl=https://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- update gradle wrapper SHA-256 sum to official value

## Testing
- `./gradlew tasks --all` *(fails: Minimum supported Gradle version is 8.11.1)*

------
https://chatgpt.com/codex/tasks/task_e_6843584ec2688322b3eaa6264cf61467