### PR TITLE
Add ColorScheme.isLight extension

### DIFF
--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/ext/ColorSchemeExt.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/ext/ColorSchemeExt.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.core.ui.ext
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.luminance
+
+/**
+ * True, wenn das aktuelle ColorScheme hell ist (Surface-Luminanz > 0.5).
+ */
+val ColorScheme.isLight: Boolean
+    get() = surface.luminance() > 0.5f

--- a/core/ui/src/main/java/org/schabi/newpipe/core/ui/theme/NewPipeTheme.kt
+++ b/core/ui/src/main/java/org/schabi/newpipe/core/ui/theme/NewPipeTheme.kt
@@ -6,12 +6,13 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import org.schabi.newpipe.core.ui.ext.isLight
 
 @Composable
 fun NewPipeTheme(content: @Composable () -> Unit) {
     val context = LocalContext.current
     val colorScheme = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        if (MaterialTheme.colorScheme.isLight()) {
+        if (MaterialTheme.colorScheme.isLight) {
             dynamicLightColorScheme(context)
         } else {
             dynamicDarkColorScheme(context)


### PR DESCRIPTION
## Summary
- add `ColorScheme.isLight` extension in `ColorSchemeExt`
- use extension property in `NewPipeTheme`

## Testing
- `gradle test --no-daemon -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435f2e0c6c8322a67976b375548d97