### PR TITLE
Enable schema generation for Room

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -10,14 +10,6 @@ android {
     defaultConfig { minSdk = 21 }
     compileOptions { sourceCompatibility = JavaVersion.VERSION_17; targetCompatibility = JavaVersion.VERSION_17 }
     kotlinOptions { jvmTarget = "17" }
-
-    kapt {
-        arguments {
-            arg("room.schemaLocation", "$projectDir/schemas")
-            arg("room.incremental", "true")
-            arg("room.expandProjection", "true")
-        }
-    }
 }
 
 dependencies {
@@ -33,3 +25,12 @@ dependencies {
     implementation("com.google.dagger:hilt-android:${rootProject.extra["hilt_version"]}")
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
 }
+
+kapt {
+    arguments {
+        arg("room.schemaLocation", "$projectDir/schemas")
+        arg("room.incremental", "true")
+        arg("room.expandProjection", "true")
+    }
+}
+

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.AutoMigrationSpec
 
-@Database(exportSchema = false,
+@Database(
     entities = [
         HistoryEntryEntity::class,
         SubscriptionEntity::class,
@@ -21,7 +21,7 @@ import androidx.room.migration.AutoMigrationSpec
         AutoMigration(from = 3, to = 4, spec = AppDatabase.Migration3To4::class),
         AutoMigration(from = 4, to = 5, spec = AppDatabase.Migration4To5::class)
     ],
-    exportSchema = false
+    exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao


### PR DESCRIPTION
## Summary
- set `exportSchema = true` in `AppDatabase`
- move Room schema `kapt` args to the end of `core/data` build file
- add empty `schemas` directory for Room

## Testing
- `./gradlew -version` *(fails: Verification of Gradle distribution failed)*

------
https://chatgpt.com/codex/tasks/task_e_684362d23aa88322be7027a7bed07e6d