### PR TITLE
Disable Room auto migrations

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -26,11 +26,3 @@ dependencies {
     kapt("com.google.dagger:hilt-compiler:${rootProject.extra["hilt_version"]}")
 }
 
-kapt {
-    arguments {
-        arg("room.schemaLocation", "$projectDir/schemas")
-        arg("room.incremental", "true")
-        arg("room.expandProjection", "true")
-    }
-}
-

--- a/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
+++ b/core/data/src/main/java/org/schabi/newpipe/core/data/db/AppDatabase.kt
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.core.data.db
 
-import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.AutoMigrationSpec
@@ -15,13 +14,7 @@ import androidx.room.migration.AutoMigrationSpec
         DownloadEntity::class
     ],
     version = 5,
-    autoMigrations = [
-        AutoMigration(from = 1, to = 2, spec = AppDatabase.Migration1To2::class),
-        AutoMigration(from = 2, to = 3, spec = AppDatabase.Migration2To3::class),
-        AutoMigration(from = 3, to = 4, spec = AppDatabase.Migration3To4::class),
-        AutoMigration(from = 4, to = 5, spec = AppDatabase.Migration4To5::class)
-    ],
-    exportSchema = true
+    exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao


### PR DESCRIPTION
## Summary
- disable auto migrations in `AppDatabase`
- stop exporting Room schema and remove schema generation block

## Testing
- `./gradlew help --no-daemon` *(fails: Verification of Gradle distribution failed)*
- `git push origin HEAD` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68436bc5bb808322a7c681f7d59c4883